### PR TITLE
✨ feat(schedule): add stack trace logging for job panic recovery

### DIFF
--- a/app/pkg/schedule/job.go
+++ b/app/pkg/schedule/job.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"runtime/debug"
 	"time"
 
 	"github.com/seakee/go-api/app/pkg/trace"
@@ -209,7 +210,10 @@ func (j *Job) runWithRecover() {
 	defer func() {
 		// Recover from panic and log the error
 		if r := recover(); r != nil {
-			j.Logger.Error(ctx, "job has a panic error", zap.Any("error", r))
+			j.Logger.Error(ctx, "job has a panic error",
+				zap.String("error", fmt.Sprintf("%v", r)),
+				zap.String("stack", string(debug.Stack())),
+			)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Add `runtime/debug` import to capture stack traces
- Enhance `runWithRecover()` panic recovery to log full stack trace
- Improve error formatting from `zap.Any` to `zap.String` for consistency

## Changes
- `app/pkg/schedule/job.go`: Enhanced panic recovery logging with stack trace for better debugging

## Test Plan
- [x] Verify scheduled jobs still execute normally
- [x] Trigger a panic in a job handler and confirm stack trace appears in logs