### PR TITLE
feat: make API route prefix configurable with go-api fallback

### DIFF
--- a/app/config/system.go
+++ b/app/config/system.go
@@ -7,6 +7,7 @@ import (
 // SysConfig defines system-wide configuration options.
 type SysConfig struct {
 	Name         string        `json:"name"`          // Application name
+	RoutePrefix  string        `json:"route_prefix"`  // HTTP route prefix
 	RunMode      string        `json:"run_mode"`      // Running mode
 	HTTPPort     string        `json:"http_port"`     // HTTP server port
 	ReadTimeout  time.Duration `json:"read_timeout"`  // Maximum request timeout

--- a/app/http/router/handler.go
+++ b/app/http/router/handler.go
@@ -15,7 +15,12 @@ import (
 func Register(engine *gin.Engine, ctx *http.Context) {
 	ctx.Engine = engine
 
-	api := engine.Group("go-api")
+	routePrefix := "go-api"
+	if ctx != nil && ctx.Config != nil && ctx.Config.System.RoutePrefix != "" {
+		routePrefix = ctx.Config.System.RoutePrefix
+	}
+
+	api := engine.Group(routePrefix)
 
 	// Set up internal API routes
 	internalAPI := api.Group("internal")

--- a/bin/configs/dev.json
+++ b/bin/configs/dev.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "name": "go-api",
+    "route_prefix": "go-api",
     "run_mode": "debug",
     "http_port": ":8080",
     "read_timeout": 60,

--- a/bin/configs/local.json.default
+++ b/bin/configs/local.json.default
@@ -1,6 +1,7 @@
 {
   "system": {
     "name": "go-api",
+    "route_prefix": "go-api",
     "run_mode": "debug",
     "http_port": ":8080",
     "read_timeout": 60,

--- a/bin/configs/prod.json
+++ b/bin/configs/prod.json
@@ -1,6 +1,7 @@
 {
   "system": {
     "name": "go-api",
+    "route_prefix": "go-api",
     "run_mode": "release",
     "http_port": ":8080",
     "read_timeout": 60,


### PR DESCRIPTION
## Summary
- add `system.route_prefix` to the runtime config model
- expose the route prefix in the shipped config templates
- load the root API route group from config instead of hard-coding `go-api`
- keep backward compatibility by falling back to `go-api` when the config value is empty or missing

## Testing
- `go test ./...` fails because the repository vendor directory is out of sync with `go.mod`
- `go test -mod=mod ./...` passes for the changed packages, but the repo still has existing failures in `command/codegen/codegen`
- existing failures are unrelated to this PR and include a missing `bin/data/sql/auth_app.sql` fixture plus pre-existing generator assertion failures