### PR TITLE
feat(codegen): add PostgreSQL schema support and fix custom primary-key generation

### DIFF
--- a/bin/data/sql/postgres/oauth_app.sql
+++ b/bin/data/sql/postgres/oauth_app.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "public"."oauth_app"
+(
+    "app_uuid"     uuid PRIMARY KEY,
+    "app_name"     varchar(80)                     NOT NULL,
+    "payload"      jsonb                           DEFAULT NULL,
+    "status"       integer                         NOT NULL DEFAULT 0,
+    "created_at"   timestamp with time zone        DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"   timestamp with time zone        DEFAULT CURRENT_TIMESTAMP
+);

--- a/command/codegen/README.md
+++ b/command/codegen/README.md
@@ -5,16 +5,17 @@ English | [中文](README_ZH.MD)
 ---
 ### Overview
 
-The Go API Code Generator is a powerful tool that automatically generates Go model and repository code from MySQL CREATE TABLE statements. It parses SQL files and creates corresponding Go structs with GORM tags, along with repository interfaces and implementations for common database operations.
+The Go API Code Generator generates Go model and repository code from SQL `CREATE TABLE` statements. It currently supports MySQL and a minimal PostgreSQL subset. It parses SQL files and creates corresponding Go structs with GORM tags, along with repository interfaces and implementations for common database operations.
 
 ### Features
 
-- **SQL Parsing**: Supports complex field type definitions (VARCHAR(255), DECIMAL(10,2), etc.)
-- **Type Mapping**: Comprehensive mapping from MySQL types to Go types
+- **SQL Parsing**: Supports common MySQL and PostgreSQL field type definitions
+- **Type Mapping**: Maps common SQL types to Go types
 - **GORM Integration**: Automatic generation of GORM tags (column, size, not null, default, etc.)
 - **Comment Support**: Preserves SQL comments as Go struct field comments
 - **Repository Generation**: Automatic generation of repository interfaces and implementations
 - **Smart Update Logic**: Generates update methods that only update non-zero fields
+- **Explicit Field Updates**: Generates `UpdateFields` for safe zero-value updates
 - **Flexible List Methods**: List methods that accept struct parameters for query conditions
 - **Batch Processing**: Process single files or entire directories
 - **Force Overwrite**: Option to overwrite existing files
@@ -37,6 +38,7 @@ go build -o codegen ./command/codegen/handler.go
 **Available Options:**
 
 - `-force`: Force overwrite existing files (default: false)
+- `-dialect`: SQL dialect, `mysql` or `postgres` (default: `mysql`)
 - `-name`: SQL file name (without .sql extension) to generate code for
 - `-sql`: SQL directory path (default: "bin/data/sql")
 - `-model`: Model output directory (default: "app/model")
@@ -48,6 +50,11 @@ go build -o codegen ./command/codegen/handler.go
 **Generate code for a single SQL file:**
 ```bash
 ./codegen -name auth_app
+```
+
+**Generate code for a PostgreSQL SQL file:**
+```bash
+./codegen -dialect=postgres -sql bin/data/sql/postgres -name oauth_app
 ```
 
 **Generate code for all SQL files in directory:**
@@ -62,7 +69,9 @@ go build -o codegen ./command/codegen/handler.go
 
 ### SQL File Format
 
-The generator expects standard MySQL CREATE TABLE statements. Here's an example:
+#### MySQL Example
+
+The generator supports standard MySQL `CREATE TABLE` statements. Example:
 
 ```sql
 CREATE TABLE `auth_app`
@@ -78,6 +87,22 @@ CREATE TABLE `auth_app`
     PRIMARY KEY (`id`),
     KEY `app_id` (`app_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = 'Application Information Table';
+```
+
+#### PostgreSQL Example
+
+The generator also supports a minimal PostgreSQL subset for single-table DDL. Example:
+
+```sql
+CREATE TABLE IF NOT EXISTS "public"."oauth_app"
+(
+    "app_uuid"   uuid PRIMARY KEY,
+    "app_name"   varchar(80)              NOT NULL,
+    "payload"    jsonb                    DEFAULT NULL,
+    "status"     integer                  NOT NULL DEFAULT 0,
+    "created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
 ```
 
 ### Generated Output
@@ -198,6 +223,49 @@ func (r *appRepo) List(ctx context.Context, app *auth.App) ([]auth.App, error) {
 | double | float64 | |
 | timestamp, datetime | time.Time | |
 | date | time.Time | |
+
+### Supported PostgreSQL Types
+
+| PostgreSQL Type | Go Type | Notes |
+|-----------------|---------|-------|
+| smallserial | int16 | |
+| serial | int32 | |
+| bigserial | int64 | |
+| integer | int32 | |
+| bigint | int64 | |
+| uuid | string | minimal support |
+| varchar | string / *string | nullable columns become pointers |
+| text | string / *string | |
+| boolean | bool / *bool | |
+| numeric | decimal.Decimal / *decimal.Decimal | |
+| jsonb | datatypes.JSON / *datatypes.JSON | |
+| bytea | []byte | |
+| timestamp with time zone, timestamptz | time.Time / *time.Time | |
+| timestamp without time zone | time.Time / *time.Time | |
+| date | time.Time / *time.Time | |
+
+### PostgreSQL Scope
+
+Current PostgreSQL support is intentionally limited. It supports:
+
+- single `CREATE TABLE` statements
+- optional schema names
+- quoted identifiers
+- single-column primary keys
+- common scalar PostgreSQL types listed above
+
+It does not yet support:
+
+- composite primary keys
+- array types
+- `COMMENT ON`
+- split definitions via `ALTER TABLE`
+- advanced PostgreSQL-specific features such as enums or domains
+
+### TODO
+
+- Add PostgreSQL generated output snippets to the README so users can quickly compare input and output.
+- Extend PostgreSQL support in a future iteration, prioritizing `COMMENT ON` and array types.
 | json | string | |
 | blob | []byte | |
 

--- a/command/codegen/README_ZH.MD
+++ b/command/codegen/README_ZH.MD
@@ -5,16 +5,17 @@
 ---
 ### 概述
 
-Go API 代码生成器是一个强大的工具，可以从 MySQL CREATE TABLE 语句自动生成 Go 模型和仓库代码。它解析 SQL 文件并创建相应的带有 GORM 标签的 Go 结构体，以及仓库接口和实现，用于常用的数据库操作。
+Go API 代码生成器可以从 SQL `CREATE TABLE` 语句生成 Go 模型和仓库代码。目前支持 MySQL，以及一个最小可用范围的 PostgreSQL 子集。它解析 SQL 文件并创建相应的带有 GORM 标签的 Go 结构体，以及仓库接口和实现，用于常用的数据库操作。
 
 ### 功能特性
 
-- **SQL 解析**: 支持复杂的字段类型定义（VARCHAR(255), DECIMAL(10,2) 等）
-- **类型映射**: 从 MySQL 类型到 Go 类型的全面映射
+- **SQL 解析**: 支持常见的 MySQL 和 PostgreSQL 字段类型定义
+- **类型映射**: 将常见 SQL 类型映射到 Go 类型
 - **GORM 集成**: 自动生成 GORM 标签（column, size, not null, default 等）
 - **注释支持**: 保留 SQL 注释作为 Go 结构体字段注释
 - **仓库生成**: 自动生成仓库接口和实现
 - **智能更新逻辑**: 生成只更新非零值字段的更新方法
+- **显式字段更新**: 生成 `UpdateFields`，安全支持零值更新
 - **灵活的列表方法**: 接受结构体参数作为查询条件的列表方法
 - **批量处理**: 处理单个文件或整个目录
 - **强制覆盖**: 可选择覆盖现有文件
@@ -37,6 +38,7 @@ go build -o codegen ./command/codegen/handler.go
 **可用选项：**
 
 - `-force`: 强制覆盖现有文件（默认：false）
+- `-dialect`: SQL 方言，`mysql` 或 `postgres`（默认：`mysql`）
 - `-name`: 要生成代码的 SQL 文件名（不含 .sql 扩展名）
 - `-sql`: SQL 目录路径（默认："bin/data/sql"）
 - `-model`: 模型输出目录（默认："app/model"）
@@ -48,6 +50,11 @@ go build -o codegen ./command/codegen/handler.go
 **为单个 SQL 文件生成代码：**
 ```bash
 ./codegen -name auth_app
+```
+
+**为 PostgreSQL SQL 文件生成代码：**
+```bash
+./codegen -dialect=postgres -sql bin/data/sql/postgres -name oauth_app
 ```
 
 **为目录中所有 SQL 文件生成代码：**
@@ -62,7 +69,9 @@ go build -o codegen ./command/codegen/handler.go
 
 ### SQL 文件格式
 
-生成器期望标准的 MySQL CREATE TABLE 语句。示例如下：
+#### MySQL 示例
+
+生成器支持标准 MySQL `CREATE TABLE` 语句。示例如下：
 
 ```sql
 CREATE TABLE `auth_app`
@@ -78,6 +87,22 @@ CREATE TABLE `auth_app`
     PRIMARY KEY (`id`),
     KEY `app_id` (`app_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '应用信息表';
+```
+
+#### PostgreSQL 示例
+
+生成器也支持一个最小范围的 PostgreSQL 单表 DDL。示例如下：
+
+```sql
+CREATE TABLE IF NOT EXISTS "public"."oauth_app"
+(
+    "app_uuid"   uuid PRIMARY KEY,
+    "app_name"   varchar(80)              NOT NULL,
+    "payload"    jsonb                    DEFAULT NULL,
+    "status"     integer                  NOT NULL DEFAULT 0,
+    "created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
 ```
 
 ### 生成的输出
@@ -198,6 +223,49 @@ func (r *appRepo) List(ctx context.Context, app *auth.App) ([]auth.App, error) {
 | double | float64 | |
 | timestamp, datetime | time.Time | |
 | date | time.Time | |
+
+### 支持的 PostgreSQL 类型
+
+| PostgreSQL 类型 | Go 类型 | 备注 |
+|-----------------|---------|------|
+| smallserial | int16 | |
+| serial | int32 | |
+| bigserial | int64 | |
+| integer | int32 | |
+| bigint | int64 | |
+| uuid | string | 最小支持版 |
+| varchar | string / *string | 可空列会映射成指针 |
+| text | string / *string | |
+| boolean | bool / *bool | |
+| numeric | decimal.Decimal / *decimal.Decimal | |
+| jsonb | datatypes.JSON / *datatypes.JSON | |
+| bytea | []byte | |
+| timestamp with time zone, timestamptz | time.Time / *time.Time | |
+| timestamp without time zone | time.Time / *time.Time | |
+| date | time.Time / *time.Time | |
+
+### PostgreSQL 支持范围
+
+当前 PostgreSQL 支持故意控制在较小范围，仅支持：
+
+- 单个 `CREATE TABLE` 语句
+- 可选 schema
+- 双引号标识符
+- 单列主键
+- 上表列出的常见标量类型
+
+当前暂不支持：
+
+- 复合主键
+- 数组类型
+- `COMMENT ON`
+- 通过 `ALTER TABLE` 拆开的定义
+- enum、domain 等更复杂的 PostgreSQL 特性
+
+### TODO
+
+- 在 README 中补充 PostgreSQL 生成结果的关键片段，方便用户快速对照输入输出。
+- 后续继续扩展 PostgreSQL 支持，优先补充 `COMMENT ON` 和数组类型。
 | json | string | |
 | blob | []byte | |
 

--- a/command/codegen/codegen/model.go
+++ b/command/codegen/codegen/model.go
@@ -649,11 +649,14 @@ func (m *Model) markPrimaryKey(columnName string) {
 		}
 		m.TableFields[i].IsPrimaryKey = true
 		m.TableFields[i].IsNullable = false
+		fieldType, importPath := m.getGoType(m.TableFields[i].SQLType, m.TableFields[i].IsUnsigned, m.TableFields[i].IsNullable)
+		m.TableFields[i].Type = fieldType
+		if importPath != "" {
+			m.Imports[importPath] = struct{}{}
+		}
 		m.HasPrimaryKey = true
 		m.PrimaryKeyName = columnName
-		if m.IDType == "" {
-			m.IDType = m.TableFields[i].Type
-		}
+		m.IDType = m.TableFields[i].Type
 		m.TableFields[i].GormTag = m.generateGormTag(&m.TableFields[i], m.TableFields[i].SQLType)
 		return
 	}
@@ -1000,7 +1003,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, db *gorm.DB) ({{.IDType}}, error) {
 	// Perform the database insert operation with context.
 	if err := db.WithContext(ctx).Create({{.StructNameFirstLetter}}).Error; err != nil {
-		return 0, fmt.Errorf("create failed: %w", err)
+		return *new({{.IDType}}), fmt.Errorf("create failed: %w", err)
 	}
 
 	return {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}}, nil

--- a/command/codegen/codegen/model.go
+++ b/command/codegen/codegen/model.go
@@ -24,6 +24,7 @@ const defaultModelOutPath = "app/model"
 // Field represents a field in a database table.
 type Field struct {
 	Name            string // The name of the field in Go struct
+	SQLType         string // The original SQL type definition
 	Type            string // The Go type of the field
 	JsonName        string // The JSON name of the field
 	GormTag         string // The GORM tag for the field
@@ -34,21 +35,38 @@ type Field struct {
 	Scale           int    // Scale for decimal types
 	IsUnsigned      bool   // Whether the field is unsigned (for numeric types)
 	IsAutoIncrement bool   // Whether the field is auto increment
+	IsPrimaryKey    bool   // Whether the field is part of the primary key
 }
 
 // Model represents the structure of a database table.
 type Model struct {
-	PackageName string              // The package name for the generated Go file
-	Imports     map[string]struct{} // Imports required by the Go file
-	StructName  string              // The name of the Go struct
-	TableName   string              // The name of the database table
-	TableFields []Field             // The fields of the table
+	PackageName    string              // The package name for the generated Go file
+	Imports        map[string]struct{} // Imports required by the Go file
+	StructName     string              // The name of the Go struct
+	TableName      string              // The unqualified table name
+	SchemaName     string              // Optional schema name
+	TableFields    []Field             // The fields of the table
+	UseGormModel   bool                // Whether the generated model can embed gorm.Model
+	IDType         string              // Primary key type used by generated methods
+	PrimaryKeyName string              // Primary key column name
+	HasPrimaryKey  bool                // Whether the table defines a single-column primary key
+	Dialect        string              // SQL dialect used by the parser
 }
 
 // NewModel creates a new instance of Model.
 func NewModel() *Model {
+	return NewModelWithDialect("mysql")
+}
+
+// NewModelWithDialect creates a new Model for the given SQL dialect.
+func NewModelWithDialect(dialect string) *Model {
+	if dialect == "" {
+		dialect = "mysql"
+	}
+
 	return &Model{
 		Imports: make(map[string]struct{}),
+		Dialect: strings.ToLower(dialect),
 	}
 }
 
@@ -61,12 +79,51 @@ func NewModel() *Model {
 // Returns:
 //   - A string representing the Go type.
 //   - A string representing the import path required for the Go type, if any.
-func (m *Model) getGoType(sqlType string, isUnsigned bool) (string, string) {
+func (m *Model) getGoType(sqlType string, isUnsigned, isNullable bool) (string, string) {
+	normalizedType := strings.ToLower(strings.TrimSpace(sqlType))
+	makeNullable := func(goType, importPath string) (string, string) {
+		if !isNullable {
+			return goType, importPath
+		}
+		switch goType {
+		case "[]byte":
+			return goType, importPath
+		default:
+			return "*" + goType, importPath
+		}
+	}
+
+	if m.Dialect == "postgres" {
+		switch {
+		case strings.HasPrefix(normalizedType, "smallserial"):
+			return makeNullable("int16", "")
+		case strings.HasPrefix(normalizedType, "serial"):
+			return makeNullable("int32", "")
+		case strings.HasPrefix(normalizedType, "bigserial"):
+			return makeNullable("int64", "")
+		case strings.HasPrefix(normalizedType, "uuid"):
+			return makeNullable("string", "")
+		case strings.HasPrefix(normalizedType, "jsonb"):
+			return makeNullable("datatypes.JSON", "gorm.io/datatypes")
+		case strings.HasPrefix(normalizedType, "bytea"):
+			return "[]byte", ""
+		case strings.HasPrefix(normalizedType, "timestamp with time zone"), strings.HasPrefix(normalizedType, "timestamp without time zone"), strings.HasPrefix(normalizedType, "timestamptz"):
+			return makeNullable("time.Time", "time")
+		case strings.HasPrefix(normalizedType, "double precision"):
+			return makeNullable("float64", "")
+		case strings.HasPrefix(normalizedType, "integer"):
+			return makeNullable("int32", "")
+		}
+	}
+
 	// Extract base type and size information
 	typeRegex := regexp.MustCompile(`^(\w+)(?:\((\d+)(?:,(\d+))?\))?`)
-	matches := typeRegex.FindStringSubmatch(sqlType)
+	matches := typeRegex.FindStringSubmatch(normalizedType)
 
 	if len(matches) == 0 {
+		if isNullable {
+			return "*any", ""
+		}
 		return "any", ""
 	}
 
@@ -75,44 +132,44 @@ func (m *Model) getGoType(sqlType string, isUnsigned bool) (string, string) {
 	switch baseType {
 	case "tinyint":
 		if isUnsigned {
-			return "uint8", ""
+			return makeNullable("uint8", "")
 		}
-		return "int8", ""
+		return makeNullable("int8", "")
 	case "smallint":
 		if isUnsigned {
-			return "uint16", ""
+			return makeNullable("uint16", "")
 		}
-		return "int16", ""
+		return makeNullable("int16", "")
 	case "mediumint", "int":
 		if isUnsigned {
-			return "uint32", ""
+			return makeNullable("uint32", "")
 		}
-		return "int32", ""
+		return makeNullable("int32", "")
 	case "bigint":
 		if isUnsigned {
-			return "uint64", ""
+			return makeNullable("uint64", "")
 		}
-		return "int64", ""
+		return makeNullable("int64", "")
 	case "float":
-		return "float32", ""
+		return makeNullable("float32", "")
 	case "double", "real":
-		return "float64", ""
+		return makeNullable("float64", "")
 	case "decimal", "numeric":
-		return "decimal.Decimal", "github.com/shopspring/decimal"
+		return makeNullable("decimal.Decimal", "github.com/shopspring/decimal")
 	case "bit":
-		return "uint64", ""
+		return makeNullable("uint64", "")
 	case "bool", "boolean":
-		return "bool", ""
+		return makeNullable("bool", "")
 	case "char", "varchar", "text", "tinytext", "mediumtext", "longtext", "enum", "set":
-		return "string", ""
+		return makeNullable("string", "")
 	case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob":
 		return "[]byte", ""
 	case "date", "time", "datetime", "timestamp", "year":
-		return "time.Time", "time"
+		return makeNullable("time.Time", "time")
 	case "json":
-		return "datatypes.JSON", "gorm.io/datatypes"
+		return makeNullable("datatypes.JSON", "gorm.io/datatypes")
 	default:
-		return "any", ""
+		return makeNullable("any", "")
 	}
 }
 
@@ -129,6 +186,14 @@ func (m *Model) getGoType(sqlType string, isUnsigned bool) (string, string) {
 // Returns:
 //   - An error if there is an issue parsing the SQL schema, otherwise nil.
 func (m *Model) parseSQL(sql string) error {
+	m.TableFields = nil
+	m.TableName = ""
+	m.SchemaName = ""
+	m.PrimaryKeyName = ""
+	m.HasPrimaryKey = false
+	m.IDType = ""
+	m.UseGormModel = false
+
 	// Split the SQL schema into lines for easier processing.
 	lines := strings.Split(sql, "\n")
 
@@ -150,10 +215,18 @@ func (m *Model) parseSQL(sql string) error {
 		case "create":
 			// If the line starts with "create table", extract the table name.
 			if len(parts) >= 3 && parts[1] == "table" {
-				m.TableName = strings.Trim(parts[2], "`")
+				m.parseCreateTableLine(originalLine)
 			}
-		case "primary", "unique", "key", "index", "constraint", "foreign", "engine", "default", "collate", "comment":
+		case "primary", "unique", "key", "index", "foreign", "engine", "default", "collate", "comment":
 			// Ignore constraint, index, and table-level configuration lines.
+			if primaryKeyName := m.extractPrimaryKeyName(originalLine); primaryKeyName != "" {
+				m.markPrimaryKey(primaryKeyName)
+			}
+			continue
+		case "constraint":
+			if primaryKeyName := m.extractPrimaryKeyName(originalLine); primaryKeyName != "" {
+				m.markPrimaryKey(primaryKeyName)
+			}
 			continue
 		default:
 			// Process lines that define fields.
@@ -167,12 +240,7 @@ func (m *Model) parseSQL(sql string) error {
 				continue
 			}
 
-			name := strings.Trim(parts[0], "`")
-			// Skip certain predefined field names.
-			if name == "id" || name == "created_at" || name == "updated_at" || name == "deleted_at" {
-				continue
-			}
-
+			name := m.cleanIdentifier(parts[0])
 			if len(parts) < 2 {
 				continue
 			}
@@ -184,6 +252,13 @@ func (m *Model) parseSQL(sql string) error {
 				m.TableFields = append(m.TableFields, *field)
 			}
 		}
+	}
+
+	m.UseGormModel = m.canUseGormModel()
+	if m.IDType == "" && m.HasPrimaryKey {
+		m.IDType = "uint"
+	} else if m.IDType == "" {
+		m.IDType = "uint"
 	}
 
 	return nil
@@ -201,16 +276,35 @@ func (m *Model) parseFieldDefinition(originalLine, fieldName string, parts []str
 	}
 
 	// Parse field type and attributes
-	typeStr := parts[1]
+	typeStr := m.extractTypeDefinition(parts)
+	field.SQLType = typeStr
 
 	// Check for UNSIGNED
 	field.IsUnsigned = strings.Contains(strings.ToUpper(originalLine), "UNSIGNED")
 
 	// Check for NOT NULL
 	field.IsNullable = !strings.Contains(strings.ToUpper(originalLine), "NOT NULL")
+	if strings.Contains(strings.ToUpper(originalLine), "PRIMARY KEY") {
+		field.IsNullable = false
+	}
 
 	// Check for AUTO_INCREMENT
 	field.IsAutoIncrement = strings.Contains(strings.ToUpper(originalLine), "AUTO_INCREMENT")
+	if m.Dialect == "postgres" {
+		upperLine := strings.ToUpper(originalLine)
+		if strings.Contains(upperLine, "GENERATED") && strings.Contains(upperLine, "AS IDENTITY") {
+			field.IsAutoIncrement = true
+		}
+		if strings.HasPrefix(strings.ToLower(typeStr), "serial") || strings.HasPrefix(strings.ToLower(typeStr), "bigserial") || strings.HasPrefix(strings.ToLower(typeStr), "smallserial") {
+			field.IsAutoIncrement = true
+			field.IsNullable = false
+		}
+	}
+
+	if strings.Contains(strings.ToUpper(originalLine), "PRIMARY KEY") {
+		field.IsPrimaryKey = true
+		field.IsNullable = false
+	}
 
 	// Extract size and scale information
 	field.Size, field.Scale = m.extractSizeAndScale(typeStr)
@@ -222,8 +316,13 @@ func (m *Model) parseFieldDefinition(originalLine, fieldName string, parts []str
 	field.Comment = m.extractComment(originalLine)
 
 	// Determine the Go type and any required import for the field.
-	fieldType, importPath := m.getGoType(typeStr, field.IsUnsigned)
+	fieldType, importPath := m.getGoType(typeStr, field.IsUnsigned, field.IsNullable)
 	field.Type = fieldType
+	if field.IsPrimaryKey {
+		m.HasPrimaryKey = true
+		m.PrimaryKeyName = field.JsonName
+		m.IDType = fieldType
+	}
 
 	if importPath != "" {
 		m.Imports[importPath] = struct{}{}
@@ -268,7 +367,11 @@ func (m *Model) extractDefaultValue(line string) string {
 	matches := defaultRegex.FindStringSubmatch(line)
 
 	if len(matches) > 1 {
-		return strings.Trim(matches[1], "'\"")
+		defaultValue := strings.Trim(matches[1], "'\"")
+		if strings.EqualFold(defaultValue, "NULL") {
+			return ""
+		}
+		return defaultValue
 	}
 
 	return ""
@@ -296,19 +399,34 @@ func (m *Model) generateGormTag(field *Field, typeStr string) string {
 
 	// Type specification for certain types
 	baseType := strings.ToLower(strings.Split(typeStr, "(")[0])
-	switch baseType {
-	case "varchar", "char":
-		if field.Size > 0 {
-			tags = append(tags, fmt.Sprintf("type:varchar(%d)", field.Size))
+	if m.Dialect == "mysql" {
+		switch baseType {
+		case "varchar", "char":
+			if field.Size > 0 {
+				tags = append(tags, fmt.Sprintf("type:varchar(%d)", field.Size))
+			}
+		case "decimal", "numeric":
+			if field.Size > 0 && field.Scale > 0 {
+				tags = append(tags, fmt.Sprintf("type:decimal(%d,%d)", field.Size, field.Scale))
+			} else if field.Size > 0 {
+				tags = append(tags, fmt.Sprintf("type:decimal(%d)", field.Size))
+			}
+		case "text", "tinytext", "mediumtext", "longtext":
+			tags = append(tags, fmt.Sprintf("type:%s", baseType))
 		}
-	case "decimal", "numeric":
-		if field.Size > 0 && field.Scale > 0 {
-			tags = append(tags, fmt.Sprintf("type:decimal(%d,%d)", field.Size, field.Scale))
-		} else if field.Size > 0 {
-			tags = append(tags, fmt.Sprintf("type:decimal(%d)", field.Size))
+	} else {
+		switch baseType {
+		case "numeric":
+			if field.Size > 0 && field.Scale > 0 {
+				tags = append(tags, fmt.Sprintf("type:numeric(%d,%d)", field.Size, field.Scale))
+			}
+		case "jsonb", "bytea", "uuid", "text", "date", "timestamp", "timestamptz":
+			tags = append(tags, fmt.Sprintf("type:%s", baseType))
+		case "varchar", "character varying":
+			if field.Size > 0 {
+				tags = append(tags, fmt.Sprintf("type:varchar(%d)", field.Size))
+			}
 		}
-	case "text", "tinytext", "mediumtext", "longtext":
-		tags = append(tags, fmt.Sprintf("type:%s", baseType))
 	}
 
 	// NOT NULL constraint
@@ -319,6 +437,10 @@ func (m *Model) generateGormTag(field *Field, typeStr string) string {
 	// Default value
 	if field.DefaultValue != "" {
 		tags = append(tags, fmt.Sprintf("default:%s", field.DefaultValue))
+	}
+
+	if field.IsPrimaryKey {
+		tags = append(tags, "primaryKey")
 	}
 
 	// Auto increment
@@ -340,6 +462,15 @@ func (m *Model) generateGormTag(field *Field, typeStr string) string {
 func (m *Model) generateCode() (string, error) {
 	// Determine the package and struct names based on the table name.
 	m.PackageName, m.StructName = m.generateNames(m.TableName)
+	displayFields := m.templateFields()
+	primaryKeyFieldName := "ID"
+	primaryKeyName := m.PrimaryKeyName
+	if primaryKeyName == "" {
+		primaryKeyName = "id"
+	}
+	if primaryKeyField := m.primaryKeyField(); primaryKeyField != nil {
+		primaryKeyFieldName = primaryKeyField.Name
+	}
 
 	// Parse the model template.
 	tmpl := template.Must(template.New("model").Parse(modelTemplate))
@@ -350,9 +481,14 @@ func (m *Model) generateCode() (string, error) {
 		"StructName":            m.StructName,
 		"StructNameFirstLetter": strings.ToLower(m.StructName[0:1]),
 		"StructNameLower":       strings.ToLower(m.StructName),
-		"TableName":             m.TableName,
-		"TableFields":           m.TableFields,
+		"TableName":             m.qualifiedTableName(),
+		"TableFields":           displayFields,
 		"Imports":               m.Imports,
+		"UseGormModel":          m.UseGormModel,
+		"IDType":                m.IDType,
+		"PrimaryKeyName":        primaryKeyName,
+		"PrimaryKeyFieldName":   primaryKeyFieldName,
+		"HasPrimaryKey":         m.HasPrimaryKey,
 	})
 	if err != nil {
 		return "", err
@@ -368,6 +504,7 @@ func (m *Model) generateCode() (string, error) {
 // - products -> package: products, struct: Product
 // - user_role_permissions -> package: user, struct: RolePermission
 func (m *Model) generateNames(tableName string) (packageName, structName string) {
+	tableName = m.cleanIdentifier(tableName)
 	parts := strings.Split(tableName, "_")
 
 	switch len(parts) {
@@ -412,6 +549,164 @@ func (m *Model) generateNames(tableName string) (packageName, structName string)
 	}
 
 	return packageName, structName
+}
+
+func (m *Model) parseCreateTableLine(line string) {
+	re := regexp.MustCompile(`(?i)^create\s+table\s+(?:if\s+not\s+exists\s+)?(.+?)(?:\s*\(|$)`)
+	matches := re.FindStringSubmatch(strings.TrimSpace(line))
+	if len(matches) < 2 {
+		return
+	}
+
+	schemaName, tableName := m.parseQualifiedName(matches[1])
+	m.SchemaName = schemaName
+	m.TableName = tableName
+}
+
+func (m *Model) parseQualifiedName(identifier string) (string, string) {
+	raw := strings.TrimSpace(identifier)
+	raw = strings.TrimSuffix(raw, "(")
+	raw = strings.TrimSpace(raw)
+	raw = strings.Trim(raw, ",")
+
+	parts := strings.Split(raw, ".")
+	if len(parts) == 1 {
+		return "", m.cleanIdentifier(parts[0])
+	}
+
+	schemaName := m.cleanIdentifier(parts[len(parts)-2])
+	tableName := m.cleanIdentifier(parts[len(parts)-1])
+	return schemaName, tableName
+}
+
+func (m *Model) cleanIdentifier(identifier string) string {
+	cleaned := strings.TrimSpace(identifier)
+	cleaned = strings.TrimSuffix(cleaned, ",")
+	cleaned = strings.Trim(cleaned, "`\"")
+	return cleaned
+}
+
+func (m *Model) qualifiedTableName() string {
+	if m.SchemaName == "" {
+		return m.TableName
+	}
+	return m.SchemaName + "." + m.TableName
+}
+
+func (m *Model) extractTypeDefinition(parts []string) string {
+	if len(parts) < 2 {
+		return ""
+	}
+
+	stopWords := map[string]struct{}{
+		"not":        {},
+		"null":       {},
+		"default":    {},
+		"comment":    {},
+		"constraint": {},
+		"primary":    {},
+		"unique":     {},
+		"references": {},
+		"check":      {},
+		"generated":  {},
+		"collate":    {},
+	}
+
+	typeParts := make([]string, 0, 3)
+	for _, part := range parts[1:] {
+		normalized := strings.ToLower(strings.Trim(part, ","))
+		if _, isStopWord := stopWords[normalized]; isStopWord {
+			break
+		}
+		typeParts = append(typeParts, normalized)
+		if normalized == "zone" || normalized == "precision" {
+			break
+		}
+	}
+
+	return strings.Join(typeParts, " ")
+}
+
+func (m *Model) extractPrimaryKeyName(line string) string {
+	re := regexp.MustCompile(`(?i)primary\s+key\s*\(([^)]+)\)`)
+	matches := re.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	columns := strings.Split(matches[1], ",")
+	if len(columns) != 1 {
+		return ""
+	}
+
+	return m.cleanIdentifier(columns[0])
+}
+
+func (m *Model) markPrimaryKey(columnName string) {
+	for i := range m.TableFields {
+		if m.TableFields[i].JsonName != columnName {
+			continue
+		}
+		m.TableFields[i].IsPrimaryKey = true
+		m.TableFields[i].IsNullable = false
+		m.HasPrimaryKey = true
+		m.PrimaryKeyName = columnName
+		if m.IDType == "" {
+			m.IDType = m.TableFields[i].Type
+		}
+		m.TableFields[i].GormTag = m.generateGormTag(&m.TableFields[i], m.TableFields[i].SQLType)
+		return
+	}
+}
+
+func (m *Model) canUseGormModel() bool {
+	requiredFields := map[string]bool{
+		"id":         false,
+		"created_at": false,
+		"updated_at": false,
+		"deleted_at": false,
+	}
+
+	for _, field := range m.TableFields {
+		if _, ok := requiredFields[field.JsonName]; ok {
+			requiredFields[field.JsonName] = true
+		}
+	}
+
+	for _, exists := range requiredFields {
+		if !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m *Model) templateFields() []Field {
+	if !m.UseGormModel {
+		return m.TableFields
+	}
+
+	fields := make([]Field, 0, len(m.TableFields))
+	for _, field := range m.TableFields {
+		switch field.JsonName {
+		case "id", "created_at", "updated_at", "deleted_at":
+			continue
+		default:
+			fields = append(fields, field)
+		}
+	}
+
+	return fields
+}
+
+func (m *Model) primaryKeyField() *Field {
+	for i := range m.TableFields {
+		if m.TableFields[i].IsPrimaryKey {
+			return &m.TableFields[i]
+		}
+	}
+	return nil
 }
 
 // readSQLFile reads the content of the specified SQL file.
@@ -592,7 +887,9 @@ import (
 )
 
 type {{.StructName}} struct {
+	{{- if .UseGormModel}}
 	gorm.Model
+	{{- end}}
 	{{"\n"}}
 	{{- range .TableFields}}
 	{{.Name}} {{.Type}} ` + "`gorm:\"{{.GormTag}}\" json:\"{{.JsonName}}\"`" + ` {{.Comment}}
@@ -679,7 +976,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 	}
 
 	// Perform the database query with context.
-	if err := query.Order("id desc").First(&{{.StructNameLower}}).Error; err != nil {
+	if err := query.Order("{{.PrimaryKeyName}} desc").First(&{{.StructNameLower}}).Error; err != nil {
 		// If no record is found, return nil without an error.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -700,13 +997,13 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 // Returns:
 // 	- uint: ID of the created {{.StructNameLower}}.
 // 	- error: error if the insert operation fails, otherwise nil.
-func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, db *gorm.DB) (uint, error) {
+func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, db *gorm.DB) ({{.IDType}}, error) {
 	// Perform the database insert operation with context.
 	if err := db.WithContext(ctx).Create({{.StructNameFirstLetter}}).Error; err != nil {
 		return 0, fmt.Errorf("create failed: %w", err)
 	}
 
-	return {{.StructNameFirstLetter}}.ID, nil
+	return {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}}, nil
 }
 
 // Delete removes the {{.StructNameLower}} from the database.
@@ -747,12 +1044,19 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Updates(ctx context.Context, 
 	// Apply Where conditions if set
 	if {{.StructNameFirstLetter}}.queryCondition != nil {
 		query = query.Where({{.StructNameFirstLetter}}.queryCondition, {{.StructNameFirstLetter}}.queryArgs...)
-	} else if {{.StructNameFirstLetter}}.ID > 0 {
-		// Use ID for updates if available (most common case)
-		query = query.Where("id = ?", {{.StructNameFirstLetter}}.ID)
 	} else {
+		{{- if .HasPrimaryKey}}
+		if {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}} != *new({{.IDType}}) {
+			// Use primary key for updates if available.
+			query = query.Where("{{.PrimaryKeyName}} = ?", {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}})
+		} else {
+			// Use struct fields as condition
+			query = query.Where({{.StructNameFirstLetter}})
+		}
+		{{- else}}
 		// Use struct fields as condition
 		query = query.Where({{.StructNameFirstLetter}})
+		{{- end}}
 	}
 
 	// Perform the database update operation with context.

--- a/command/codegen/codegen/model_test.go
+++ b/command/codegen/codegen/model_test.go
@@ -486,3 +486,61 @@ func TestModel_parseSQLPostgres(t *testing.T) {
 		t.Fatalf("expected jsonb field mapping in generated code, got:\n%s", code)
 	}
 }
+
+func TestModel_parseSQLPostgresTableLevelPrimaryKeyRecomputesType(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE oauth_apps (
+		app_uuid uuid,
+		name varchar(80) NOT NULL,
+		PRIMARY KEY (app_uuid)
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if m.PrimaryKeyName != "app_uuid" {
+		t.Fatalf("PrimaryKeyName = %s, want app_uuid", m.PrimaryKeyName)
+	}
+	if m.IDType != "string" {
+		t.Fatalf("IDType = %s, want string", m.IDType)
+	}
+
+	var pkField *Field
+	for i := range m.TableFields {
+		if m.TableFields[i].JsonName == "app_uuid" {
+			pkField = &m.TableFields[i]
+			break
+		}
+	}
+	if pkField == nil {
+		t.Fatal("primary key field app_uuid not found")
+	}
+	if pkField.Type != "string" {
+		t.Fatalf("pkField.Type = %s, want string", pkField.Type)
+	}
+	if pkField.IsNullable {
+		t.Fatal("primary key field should be non-nullable")
+	}
+}
+
+func TestModel_generateCodeCreateUsesTypedZeroValueOnError(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE oauth_apps (
+		app_uuid uuid PRIMARY KEY,
+		name varchar(80) NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if !strings.Contains(code, "return *new(string), fmt.Errorf(\"create failed: %w\", err)") {
+		t.Fatalf("expected create error branch to return typed zero value, got:\n%s", code)
+	}
+}

--- a/command/codegen/codegen/model_test.go
+++ b/command/codegen/codegen/model_test.go
@@ -5,16 +5,25 @@
 package codegen
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // TestModel_Generate tests the complete model generation process
 func TestModel_Generate(t *testing.T) {
 	m := NewModel()
+	outputDir := t.TempDir()
 
-	err := m.Generate(false, "../../../bin/data/sql/auth_app.sql", "")
+	err := m.Generate(true, "../../../bin/data/sql/mysql/auth_app.sql", outputDir)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	generatedPath := filepath.Join(outputDir, "auth", "app.go")
+	if _, err := os.Stat(generatedPath); err != nil {
+		t.Fatalf("generated file missing: %v", err)
 	}
 }
 
@@ -27,7 +36,10 @@ func TestModel_parseSQL(t *testing.T) {
 		id int NOT NULL AUTO_INCREMENT COMMENT 'id',
 		app_id varchar(30) NOT NULL COMMENT '应用ID',
 		app_name varchar(50) DEFAULT NULL COMMENT '应用名称',
-		status tinyint(1) NOT NULL DEFAULT '0' COMMENT '状态'
+		status tinyint(1) NOT NULL DEFAULT '0' COMMENT '状态',
+		created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		deleted_at timestamp NULL DEFAULT NULL
 	);`
 
 	err := m.parseSQL(sqlContent)
@@ -37,6 +49,10 @@ func TestModel_parseSQL(t *testing.T) {
 
 	if m.TableName != "auth_app" {
 		t.Errorf("TableName = %v, want auth_app", m.TableName)
+	}
+
+	if !m.UseGormModel {
+		t.Error("expected auth_app to embed gorm.Model")
 	}
 
 	// Debug: print all parsed fields
@@ -51,31 +67,30 @@ func TestModel_parseSQL(t *testing.T) {
 		t.Error("No fields were parsed")
 	}
 
-	// Test that we have the expected fields (id is skipped by design)
+	// Test that we have the expected fields.
 	if len(m.TableFields) > 0 {
-		// First field should be app_id
-		appIdField := m.TableFields[0]
+		appIdField := m.TableFields[1]
 		if appIdField.Name != "AppId" {
-			t.Errorf("First field name = %v, want AppId", appIdField.Name)
+			t.Errorf("AppId field name = %v, want AppId", appIdField.Name)
 		}
 		if appIdField.Type != "string" {
-			t.Errorf("First field type = %v, want string", appIdField.Type)
+			t.Errorf("AppId field type = %v, want string", appIdField.Type)
 		}
 		if appIdField.IsNullable {
 			t.Errorf("AppId field should not be nullable")
 		}
 	}
 
-	// Test that we have at least 3 fields (app_id, app_name, status)
-	if len(m.TableFields) < 3 {
-		t.Errorf("Expected at least 3 fields, got %d", len(m.TableFields))
+	// Standard GORM fields are parsed, then filtered at template time.
+	if len(m.TableFields) < 4 {
+		t.Errorf("Expected parsed fields to include standard columns, got %d", len(m.TableFields))
 	}
 
 	// Test status field properties
-	if len(m.TableFields) >= 3 {
-		statusField := m.TableFields[2] // status is the 3rd field
+	if len(m.TableFields) >= 4 {
+		statusField := m.TableFields[3]
 		if statusField.Name != "Status" {
-			t.Errorf("Third field name = %v, want Status", statusField.Name)
+			t.Errorf("Status field name = %v, want Status", statusField.Name)
 		}
 		if statusField.Type != "int8" {
 			t.Errorf("Status field type = %v, want int8", statusField.Type)
@@ -86,6 +101,37 @@ func TestModel_parseSQL(t *testing.T) {
 		if statusField.DefaultValue != "0" {
 			t.Errorf("Status field default value = %v, want 0", statusField.DefaultValue)
 		}
+	}
+}
+
+func TestModel_parseSQLWithoutStandardFields(t *testing.T) {
+	m := NewModel()
+
+	sqlContent := `CREATE TABLE custom_job (
+		id bigint NOT NULL AUTO_INCREMENT COMMENT 'id',
+		name varchar(64) DEFAULT NULL COMMENT 'name',
+		run_at timestamp NULL DEFAULT NULL COMMENT 'run time'
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if m.UseGormModel {
+		t.Fatal("custom_job should not embed gorm.Model")
+	}
+
+	fields := m.templateFields()
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 template fields, got %d", len(fields))
+	}
+
+	if fields[1].Type != "*string" {
+		t.Fatalf("nullable varchar should map to *string, got %s", fields[1].Type)
+	}
+
+	if fields[2].Type != "*time.Time" {
+		t.Fatalf("nullable timestamp should map to *time.Time, got %s", fields[2].Type)
 	}
 }
 
@@ -143,6 +189,17 @@ func TestModel_generateGormTag(t *testing.T) {
 			},
 			typeStr:  "tinyint(1)",
 			expected: "column:status;not null;default:0",
+		},
+		{
+			name: "field with null default skips tag",
+			field: Field{
+				Name:       "AppName",
+				JsonName:   "app_name",
+				Size:       50,
+				IsNullable: true,
+			},
+			typeStr:  "varchar(50)",
+			expected: "column:app_name;type:varchar(50)",
 		},
 		{
 			name: "nullable field",
@@ -262,7 +319,7 @@ func TestModel_extractDefaultValue(t *testing.T) {
 		expected string
 	}{
 		{"string default", "status tinyint(1) DEFAULT '0'", "0"},
-		{"null default", "name varchar(50) DEFAULT NULL", "NULL"},
+		{"null default", "name varchar(50) DEFAULT NULL", ""},
 		{"current timestamp", "created_at timestamp DEFAULT CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP"},
 		{"no default", "id int NOT NULL", ""},
 		{"numeric default", "count int DEFAULT 100", "100"},
@@ -286,42 +343,146 @@ func TestModel_getGoType(t *testing.T) {
 		name       string
 		sqlType    string
 		isUnsigned bool
+		isNullable bool
 		expected   string
 	}{
-		{"int", "int", false, "int32"},
-		{"int unsigned", "int", true, "uint32"},
-		{"tinyint", "tinyint", false, "int8"},
-		{"tinyint unsigned", "tinyint", true, "uint8"},
-		{"smallint", "smallint", false, "int16"},
-		{"smallint unsigned", "smallint", true, "uint16"},
-		{"bigint", "bigint", false, "int64"},
-		{"bigint unsigned", "bigint", true, "uint64"},
-		{"varchar", "varchar", false, "string"},
-		{"text", "text", false, "string"},
-		{"tinytext", "tinytext", false, "string"},
-		{"mediumtext", "mediumtext", false, "string"},
-		{"longtext", "longtext", false, "string"},
-		{"decimal", "decimal", false, "decimal.Decimal"},
-		{"float", "float", false, "float32"},
-		{"double", "double", false, "float64"},
-		{"timestamp", "timestamp", false, "time.Time"},
-		{"datetime", "datetime", false, "time.Time"},
-		{"date", "date", false, "time.Time"},
-		{"time", "time", false, "time.Time"},
-		{"blob", "blob", false, "[]byte"},
-		{"tinyblob", "tinyblob", false, "[]byte"},
-		{"mediumblob", "mediumblob", false, "[]byte"},
-		{"longblob", "longblob", false, "[]byte"},
-		{"json", "json", false, "datatypes.JSON"},
-		{"unknown", "unknown", false, "any"},
+		{"int", "int", false, false, "int32"},
+		{"int unsigned", "int", true, false, "uint32"},
+		{"tinyint", "tinyint", false, false, "int8"},
+		{"tinyint unsigned", "tinyint", true, false, "uint8"},
+		{"smallint", "smallint", false, false, "int16"},
+		{"smallint unsigned", "smallint", true, false, "uint16"},
+		{"bigint", "bigint", false, false, "int64"},
+		{"bigint unsigned", "bigint", true, false, "uint64"},
+		{"nullable bigint", "bigint", false, true, "*int64"},
+		{"varchar", "varchar", false, false, "string"},
+		{"nullable varchar", "varchar", false, true, "*string"},
+		{"text", "text", false, false, "string"},
+		{"tinytext", "tinytext", false, false, "string"},
+		{"mediumtext", "mediumtext", false, false, "string"},
+		{"longtext", "longtext", false, false, "string"},
+		{"decimal", "decimal", false, false, "decimal.Decimal"},
+		{"nullable decimal", "decimal", false, true, "*decimal.Decimal"},
+		{"float", "float", false, false, "float32"},
+		{"double", "double", false, false, "float64"},
+		{"timestamp", "timestamp", false, false, "time.Time"},
+		{"nullable timestamp", "timestamp", false, true, "*time.Time"},
+		{"datetime", "datetime", false, false, "time.Time"},
+		{"date", "date", false, false, "time.Time"},
+		{"time", "time", false, false, "time.Time"},
+		{"blob", "blob", false, false, "[]byte"},
+		{"tinyblob", "tinyblob", false, false, "[]byte"},
+		{"mediumblob", "mediumblob", false, false, "[]byte"},
+		{"longblob", "longblob", false, false, "[]byte"},
+		{"json", "json", false, false, "datatypes.JSON"},
+		{"nullable json", "json", false, true, "*datatypes.JSON"},
+		{"unknown", "unknown", false, false, "any"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := m.getGoType(tt.sqlType, tt.isUnsigned)
+			result, _ := m.getGoType(tt.sqlType, tt.isUnsigned, tt.isNullable)
 			if result != tt.expected {
 				t.Errorf("getGoType(%v, %v) = %v, want %v", tt.sqlType, tt.isUnsigned, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestModel_getGoTypePostgres(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+
+	tests := []struct {
+		name       string
+		sqlType    string
+		isNullable bool
+		expected   string
+	}{
+		{"serial", "serial", false, "int32"},
+		{"bigserial", "bigserial", false, "int64"},
+		{"uuid", "uuid", false, "string"},
+		{"jsonb", "jsonb", false, "datatypes.JSON"},
+		{"nullable timestamptz", "timestamptz", true, "*time.Time"},
+		{"double precision", "double precision", false, "float64"},
+		{"bytea", "bytea", false, "[]byte"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _ := m.getGoType(tt.sqlType, false, tt.isNullable)
+			if result != tt.expected {
+				t.Fatalf("getGoType(%q) = %s, want %s", tt.sqlType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestModel_generateCodeWithoutGormModel(t *testing.T) {
+	m := NewModel()
+	sqlContent := `CREATE TABLE job (
+		id bigint NOT NULL AUTO_INCREMENT COMMENT 'id',
+		name varchar(64) DEFAULT NULL COMMENT 'name'
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if strings.Contains(code, "gorm.Model") {
+		t.Fatal("unexpected gorm.Model embed for partial standard table")
+	}
+
+	if !strings.Contains(code, "Id int64") {
+		t.Fatal("expected explicit ID field in generated code")
+	}
+}
+
+func TestModel_parseSQLPostgres(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE IF NOT EXISTS "public"."oauth_apps" (
+		"app_uuid" uuid PRIMARY KEY,
+		"name" varchar(80) NOT NULL,
+		"payload" jsonb,
+		"created_at" timestamp with time zone NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if m.SchemaName != "public" {
+		t.Fatalf("SchemaName = %s, want public", m.SchemaName)
+	}
+	if m.TableName != "oauth_apps" {
+		t.Fatalf("TableName = %s, want oauth_apps", m.TableName)
+	}
+	if m.PrimaryKeyName != "app_uuid" {
+		t.Fatalf("PrimaryKeyName = %s, want app_uuid", m.PrimaryKeyName)
+	}
+	if m.IDType != "string" {
+		t.Fatalf("IDType = %s, want string", m.IDType)
+	}
+	if m.UseGormModel {
+		t.Fatal("postgres sample should not embed gorm.Model")
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if !strings.Contains(code, `return "public.oauth_apps"`) {
+		t.Fatalf("expected qualified postgres table name, got:\n%s", code)
+	}
+	if !strings.Contains(code, "AppUuid string") {
+		t.Fatalf("expected uuid primary key field in generated code, got:\n%s", code)
+	}
+	if !strings.Contains(code, "Payload *datatypes.JSON") {
+		t.Fatalf("expected jsonb field mapping in generated code, got:\n%s", code)
 	}
 }

--- a/command/codegen/codegen/repository.go
+++ b/command/codegen/codegen/repository.go
@@ -25,6 +25,8 @@ type Repository struct {
 	StructName      string              // The name of the repository struct
 	ModelStructName string              // The name of the model struct
 	TableName       string              // The name of the database table
+	IDType          string              // The primary key type used by generated methods
+	PrimaryKeyName  string              // The primary key column name used by generated methods
 }
 
 // NewRepository creates a new instance of Repository.
@@ -36,6 +38,8 @@ func NewRepository(model *Model) *Repository {
 		ModelStructName: model.StructName,
 		TableName:       model.TableName,
 		Imports:         make(map[string]struct{}),
+		IDType:          model.IDType,
+		PrimaryKeyName:  model.PrimaryKeyName,
 	}
 }
 
@@ -53,6 +57,11 @@ func (r *Repository) generateCode() (string, error) {
 	r.StructName = r.Model.StructName
 	r.ModelStructName = r.Model.StructName
 	r.TableName = r.Model.TableName
+	r.IDType = r.Model.IDType
+	r.PrimaryKeyName = r.Model.PrimaryKeyName
+	if r.PrimaryKeyName == "" {
+		r.PrimaryKeyName = "id"
+	}
 
 	// Add required imports
 	r.Imports["errors"] = struct{}{}
@@ -80,6 +89,9 @@ func (r *Repository) generateCode() (string, error) {
 		"Imports":               r.Imports,
 		"FieldChecks":           fieldChecks,
 		"QueryConditions":       queryConditions,
+		"IDType":                r.IDType,
+		"PrimaryKeyName":        r.PrimaryKeyName,
+		"PrimaryKeyFieldName":   r.primaryKeyFieldName(),
 	}
 
 	// Parse and execute the template
@@ -96,6 +108,15 @@ func (r *Repository) generateCode() (string, error) {
 	return buf.String(), nil
 }
 
+func (r *Repository) primaryKeyFieldName() string {
+	for _, field := range r.Model.TableFields {
+		if field.JsonName == r.PrimaryKeyName {
+			return field.Name
+		}
+	}
+	return "ID"
+}
+
 // generateFieldChecks generates field check code for the Update method
 func (r *Repository) generateFieldChecks() string {
 	var checks []string
@@ -103,7 +124,7 @@ func (r *Repository) generateFieldChecks() string {
 
 	for _, field := range r.Model.TableFields {
 		// Skip ID field as it's used for identification
-		if strings.ToLower(field.Name) == "id" {
+		if field.JsonName == r.PrimaryKeyName {
 			continue
 		}
 
@@ -138,6 +159,10 @@ func (r *Repository) generateFieldChecks() string {
 		case "time.Time":
 			checkCondition = fmt.Sprintf(`if !%s.%s.IsZero() {`, modelStructNameLower, field.Name)
 		case "*time.Time":
+			checkCondition = fmt.Sprintf(`if %s.%s != nil {`, modelStructNameLower, field.Name)
+		case "decimal.Decimal", "datatypes.JSON", "[]byte":
+			checkCondition = fmt.Sprintf(`if %s.%s != nil {`, modelStructNameLower, field.Name)
+		case "*decimal.Decimal", "*datatypes.JSON":
 			checkCondition = fmt.Sprintf(`if %s.%s != nil {`, modelStructNameLower, field.Name)
 		default:
 			// For other types, use nil check
@@ -185,6 +210,10 @@ func (r *Repository) generateQueryConditions() string {
 		case "time.Time":
 			conditionCheck = fmt.Sprintf(`if !%s.%s.IsZero() {`, modelStructNameLower, field.Name)
 		case "*time.Time":
+			conditionCheck = fmt.Sprintf(`if %s.%s != nil {`, modelStructNameLower, field.Name)
+		case "decimal.Decimal", "datatypes.JSON", "[]byte":
+			conditionCheck = fmt.Sprintf(`if %s.%s != nil {`, modelStructNameLower, field.Name)
+		case "*decimal.Decimal", "*datatypes.JSON":
 			conditionCheck = fmt.Sprintf(`if %s.%s != nil {`, modelStructNameLower, field.Name)
 		default:
 			// For other types, use nil check
@@ -341,19 +370,22 @@ type {{.StructName}}Repo interface {
 	Get{{.ModelStructName}}(ctx context.Context, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) (*{{.LowerStructName}}.{{.ModelStructName}}, error)
 
 	// Create inserts a new {{.ModelStructNameLower}} into the database.
-	Create(ctx context.Context, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) (uint, error)
+	Create(ctx context.Context, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) ({{.IDType}}, error)
 
 	// Update updates an existing {{.ModelStructNameLower}} in the database.
-	Update(ctx context.Context, id uint, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) error
+	Update(ctx context.Context, id {{.IDType}}, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) error
+
+	// UpdateFields updates an existing {{.ModelStructNameLower}} with explicit field values.
+	UpdateFields(ctx context.Context, id {{.IDType}}, data map[string]interface{}) error
 
 	// Delete deletes a {{.ModelStructNameLower}} by its ID.
-	Delete(ctx context.Context, id uint) error
+	Delete(ctx context.Context, id {{.IDType}}) error
 
 	// List retrieves {{.ModelStructNameLower}} records based on query conditions.
 	List(ctx context.Context, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) ([]{{.LowerStructName}}.{{.ModelStructName}}, error)
 
 	// GetByID retrieves a {{.ModelStructNameLower}} by its ID.
-	GetByID(ctx context.Context, id uint) (*{{.LowerStructName}}.{{.ModelStructName}}, error)
+	GetByID(ctx context.Context, id {{.IDType}}) (*{{.LowerStructName}}.{{.ModelStructName}}, error)
 }
 
 // {{.ModelStructNameLower}}Repo implements the {{.StructName}}Repo interface.
@@ -402,7 +434,7 @@ func (r *{{.ModelStructNameLower}}Repo) Get{{.ModelStructName}}(ctx context.Cont
 // Returns:
 //   - uint: the ID of the created {{.ModelStructNameLower}}.
 //   - error: error if the creation fails, otherwise nil.
-func (r *{{.ModelStructNameLower}}Repo) Create(ctx context.Context, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) (uint, error) {
+func (r *{{.ModelStructNameLower}}Repo) Create(ctx context.Context, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) ({{.IDType}}, error) {
 	return {{.ModelStructNameLower}}.Create(ctx, r.db)
 }
 
@@ -415,9 +447,9 @@ func (r *{{.ModelStructNameLower}}Repo) Create(ctx context.Context, {{.ModelStru
 // Returns:
 //   - *{{.LowerStructName}}.{{.ModelStructName}}: pointer to the retrieved {{.ModelStructNameLower}}, or nil if not found.
 //   - error: error if the query fails, otherwise nil.
-func (r *{{.ModelStructNameLower}}Repo) GetByID(ctx context.Context, id uint) (*{{.LowerStructName}}.{{.ModelStructName}}, error) {
+func (r *{{.ModelStructNameLower}}Repo) GetByID(ctx context.Context, id {{.IDType}}) (*{{.LowerStructName}}.{{.ModelStructName}}, error) {
 	{{.ModelStructNameLower}} := &{{.LowerStructName}}.{{.ModelStructName}}{}
-	return {{.ModelStructNameLower}}.Where("id = ?", id).First(ctx, r.db)
+	return {{.ModelStructNameLower}}.Where("{{.PrimaryKeyName}} = ?", id).First(ctx, r.db)
 }
 
 // Update updates an existing {{.ModelStructNameLower}} record using the model's Updates method.
@@ -432,7 +464,7 @@ func (r *{{.ModelStructNameLower}}Repo) GetByID(ctx context.Context, id uint) (*
 //
 // Note: This method will only update non-zero value fields. You need to manually check
 // each field and add it to the data map if it's not a zero value.
-func (r *{{.ModelStructNameLower}}Repo) Update(ctx context.Context, id uint, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) error {
+func (r *{{.ModelStructNameLower}}Repo) Update(ctx context.Context, id {{.IDType}}, {{.ModelStructNameLower}} *{{.LowerStructName}}.{{.ModelStructName}}) error {
 	data := make(map[string]interface{})
 	
 {{.FieldChecks}}
@@ -442,7 +474,19 @@ func (r *{{.ModelStructNameLower}}Repo) Update(ctx context.Context, id uint, {{.
 	}
 
 	updateModel := &{{.LowerStructName}}.{{.ModelStructName}}{}
-	updateModel.ID = id
+	updateModel.{{.PrimaryKeyFieldName}} = id
+
+	return updateModel.Updates(ctx, r.db, data)
+}
+
+// UpdateFields updates a {{.ModelStructNameLower}} with explicit field values.
+func (r *{{.ModelStructNameLower}}Repo) UpdateFields(ctx context.Context, id {{.IDType}}, data map[string]interface{}) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	updateModel := &{{.LowerStructName}}.{{.ModelStructName}}{}
+	updateModel.{{.PrimaryKeyFieldName}} = id
 
 	return updateModel.Updates(ctx, r.db, data)
 }
@@ -455,9 +499,9 @@ func (r *{{.ModelStructNameLower}}Repo) Update(ctx context.Context, id uint, {{.
 //
 // Returns:
 //   - error: error if the deletion fails, otherwise nil.
-func (r *{{.ModelStructNameLower}}Repo) Delete(ctx context.Context, id uint) error {
+func (r *{{.ModelStructNameLower}}Repo) Delete(ctx context.Context, id {{.IDType}}) error {
 	{{.ModelStructNameLower}} := &{{.LowerStructName}}.{{.ModelStructName}}{}
-	return {{.ModelStructNameLower}}.Where("id = ?", id).Delete(ctx, r.db)
+	return {{.ModelStructNameLower}}.Where("{{.PrimaryKeyName}} = ?", id).Delete(ctx, r.db)
 }
 
 // List retrieves {{.ModelStructNameLower}} records based on query conditions using the model's List method.

--- a/command/codegen/codegen/repository_test.go
+++ b/command/codegen/codegen/repository_test.go
@@ -17,6 +17,7 @@ func TestRepository_generateCode(t *testing.T) {
 		PackageName: "auth",
 		StructName:  "App",
 		TableName:   "auth_app",
+		IDType:      "uint",
 		TableFields: []Field{
 			{
 				Name:    "ID",
@@ -45,18 +46,18 @@ func TestRepository_generateCode(t *testing.T) {
 	// Verify the generated code contains expected elements
 	expectedElements := []string{
 		"package auth",
-		"type AppRepository struct",
-		"NewAppRepository",
-		"func (a *AppRepository) Create",
-		"func (a *AppRepository) GetByID",
-		"func (a *AppRepository) Update",
-		"func (a *AppRepository) Delete",
-		"func (a *AppRepository) List",
-		"func (a *AppRepository) Count",
+		"type AppRepo interface",
+		"type appRepo struct",
+		"NewAppRepo",
+		"func (r *appRepo) Create",
+		"func (r *appRepo) GetByID",
+		"func (r *appRepo) Update",
+		"func (r *appRepo) UpdateFields",
+		"func (r *appRepo) Delete",
+		"func (r *appRepo) List",
 		"gorm.io/gorm",
 		"context",
-		"fmt",
-		"errors",
+		"github.com/sk-pkg/redis",
 	}
 
 	for _, element := range expectedElements {
@@ -72,6 +73,7 @@ func TestRepository_WriteRepositoryFile(t *testing.T) {
 		PackageName: "test",
 		StructName:  "TestModel",
 		TableName:   "test_model",
+		IDType:      "uint",
 	}
 
 	// Create repository instance
@@ -117,6 +119,7 @@ func TestRepository_Generate(t *testing.T) {
 		PackageName: "auth",
 		StructName:  "App",
 		TableName:   "auth_app",
+		IDType:      "uint",
 		TableFields: []Field{
 			{
 				Name:    "ID",
@@ -159,21 +162,13 @@ func TestRepository_Generate(t *testing.T) {
 
 	contentStr := string(content)
 	expectedMethods := []string{
-		"NewAppRepository",
+		"NewAppRepo",
 		"Create",
 		"GetByID",
 		"Update",
-		"UpdateFields",
 		"Delete",
 		"List",
-		"ListWithPagination",
-		"Count",
-		"FindByCondition",
-		"FirstByCondition",
-		"BatchCreate",
-		"BatchDelete",
-		"Exists",
-		"Transaction",
+		"UpdateFields",
 	}
 
 	for _, method := range expectedMethods {
@@ -189,6 +184,7 @@ func TestNewRepository(t *testing.T) {
 		PackageName: "test",
 		StructName:  "TestModel",
 		TableName:   "test_model",
+		IDType:      "uint",
 	}
 
 	// Create repository instance
@@ -205,5 +201,56 @@ func TestNewRepository(t *testing.T) {
 
 	if repo.Imports == nil {
 		t.Error("Repository imports map is nil")
+	}
+}
+
+func TestRepository_GenerateCodeUsesCustomIDType(t *testing.T) {
+	model := &Model{
+		PackageName:    "job",
+		StructName:     "Task",
+		TableName:      "job_task",
+		IDType:         "int64",
+		PrimaryKeyName: "id",
+		TableFields: []Field{
+			{Name: "ID", JsonName: "id", Type: "int64"},
+			{Name: "Name", JsonName: "name", Type: "string"},
+		},
+	}
+
+	repo := NewRepository(model)
+	code, err := repo.generateCode()
+	if err != nil {
+		t.Fatalf("Failed to generate repository code: %v", err)
+	}
+
+	if !strings.Contains(code, "GetByID(ctx context.Context, id int64)") {
+		t.Fatalf("expected generated repository to use int64 IDs, got:\n%s", code)
+	}
+}
+
+func TestRepository_GenerateCodeUsesPostgresPrimaryKeyName(t *testing.T) {
+	model := &Model{
+		PackageName:    "oauth",
+		StructName:     "App",
+		TableName:      "oauth_apps",
+		IDType:         "string",
+		PrimaryKeyName: "app_uuid",
+		TableFields: []Field{
+			{Name: "AppUuid", JsonName: "app_uuid", Type: "string", IsPrimaryKey: true},
+			{Name: "Name", JsonName: "name", Type: "string"},
+		},
+	}
+
+	repo := NewRepository(model)
+	code, err := repo.generateCode()
+	if err != nil {
+		t.Fatalf("Failed to generate repository code: %v", err)
+	}
+
+	if !strings.Contains(code, `Where("app_uuid = ?", id)`) {
+		t.Fatalf("expected generated repository to query by postgres primary key, got:\n%s", code)
+	}
+	if !strings.Contains(code, "updateModel.AppUuid = id") {
+		t.Fatalf("expected generated repository to assign custom primary key field, got:\n%s", code)
 	}
 }

--- a/command/codegen/handler.go
+++ b/command/codegen/handler.go
@@ -16,6 +16,7 @@ import (
 // It defines and parses command line flags and calls the appropriate function to process SQL files based on the provided flags.
 func main() {
 	// Define command line flags
+	dialect := flag.String("dialect", "mysql", "SQL dialect: mysql or postgres")
 	force := flag.Bool("force", false, "force overwrite existing files")
 	name := flag.String("name", "", "SQL file name (without .sql extension) in the bin/data/sql directory to generate code for")
 	sqlPath := flag.String("sql", "bin/data/sql", "SQL directory")
@@ -28,10 +29,10 @@ func main() {
 
 	if *name != "" {
 		// If the name parameter is provided, process a single SQL file
-		processSingleSQLFile(*force, *name, *sqlPath, *modelOutputPath, *repoOutputPath, *serviceOutputPath)
+		processSingleSQLFile(*dialect, *force, *name, *sqlPath, *modelOutputPath, *repoOutputPath, *serviceOutputPath)
 	} else {
 		// Otherwise, process all SQL files in the sqlPath directory
-		processSQLDirectory(*force, *sqlPath, *modelOutputPath, *repoOutputPath, *serviceOutputPath)
+		processSQLDirectory(*dialect, *force, *sqlPath, *modelOutputPath, *repoOutputPath, *serviceOutputPath)
 	}
 }
 
@@ -44,9 +45,9 @@ func main() {
 //   - modelOutputPath: directory to output the generated model code
 //   - repoOutputPath: directory to output the generated repository code
 //   - serviceOutputPath: directory to output the generated service code
-func processSingleSQLFile(force bool, name, sqlPath, modelOutputPath, repoOutputPath, serviceOutputPath string) {
+func processSingleSQLFile(dialect string, force bool, name, sqlPath, modelOutputPath, repoOutputPath, serviceOutputPath string) {
 	// Create a new Model instance
-	m := codegen.NewModel()
+	m := codegen.NewModelWithDialect(dialect)
 
 	// Construct the full path to the SQL file
 	sqlFilePath := filepath.Join(sqlPath, name+".sql")
@@ -76,7 +77,7 @@ func processSingleSQLFile(force bool, name, sqlPath, modelOutputPath, repoOutput
 //   - modelOutputPath: directory to output the generated model code
 //   - repoOutputPath: directory to output the generated repository code
 //   - serviceOutputPath: directory to output the generated service code
-func processSQLDirectory(force bool, sqlPath, modelOutputPath, repoOutputPath, serviceOutputPath string) {
+func processSQLDirectory(dialect string, force bool, sqlPath, modelOutputPath, repoOutputPath, serviceOutputPath string) {
 	// Walk through all files in the sqlPath directory
 	err := filepath.Walk(sqlPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -85,7 +86,7 @@ func processSQLDirectory(force bool, sqlPath, modelOutputPath, repoOutputPath, s
 		// If the file is not a directory and has a .sql extension, generate the corresponding code
 		if !info.IsDir() && filepath.Ext(path) == ".sql" {
 			// Create a new Model instance
-			m := codegen.NewModel()
+			m := codegen.NewModelWithDialect(dialect)
 			// Generate the model code
 			if err = m.Generate(force, path, modelOutputPath); err != nil {
 				return err


### PR DESCRIPTION
## Summary
Add PostgreSQL support to code generation and fix primary-key handling for custom/non-numeric IDs.

## Changes
- Add minimal PostgreSQL schema parsing support in codegen.
- Document PostgreSQL usage and sample schema.
- Fix generated `Create` error return to use typed zero values for dynamic ID types.
- Recompute field type/ID type when table-level `PRIMARY KEY (...)` marks a field non-null.
- Add regression tests for UUID/string PK and table-level PK without explicit `NOT NULL`.

## Testing
- [x] go test ./command/codegen/codegen
- [x] go test ./command/codegen/...

## Impact
- Prevents compile failures for generated models using UUID/string/pointer-like ID types.
- Ensures PK field/type consistency for table-level primary key declarations.