### PR TITLE
fix(codegen): harden PostgreSQL identifier handling in codegen

### DIFF
--- a/command/codegen/codegen/model.go
+++ b/command/codegen/codegen/model.go
@@ -101,6 +101,8 @@ func (m *Model) getGoType(sqlType string, isUnsigned, isNullable bool) (string, 
 			return makeNullable("int32", "")
 		case strings.HasPrefix(normalizedType, "bigserial"):
 			return makeNullable("int64", "")
+		case strings.HasPrefix(normalizedType, "character varying"), strings.HasPrefix(normalizedType, "varchar"):
+			return makeNullable("string", "")
 		case strings.HasPrefix(normalizedType, "uuid"):
 			return makeNullable("string", "")
 		case strings.HasPrefix(normalizedType, "jsonb"):
@@ -234,9 +236,8 @@ func (m *Model) parseSQL(sql string) error {
 				continue
 			}
 
-			// Skip lines that contain table-level configurations
-			if strings.Contains(line, "engine") || strings.Contains(line, "charset") ||
-				strings.Contains(line, "collate") && !strings.Contains(line, "`") {
+			// Skip lines that contain table-level configurations.
+			if strings.Contains(line, "engine") || strings.Contains(line, "charset") {
 				continue
 			}
 
@@ -462,14 +463,27 @@ func (m *Model) generateGormTag(field *Field, typeStr string) string {
 func (m *Model) generateCode() (string, error) {
 	// Determine the package and struct names based on the table name.
 	m.PackageName, m.StructName = m.generateNames(m.TableName)
+	if m.TableName == "" {
+		return "", fmt.Errorf("table name is empty")
+	}
+	if m.PackageName == "" || m.StructName == "" {
+		return "", fmt.Errorf("invalid table name: %s", m.TableName)
+	}
+
 	displayFields := m.templateFields()
-	primaryKeyFieldName := "ID"
+	primaryKeyFieldName := ""
 	primaryKeyName := m.PrimaryKeyName
 	if primaryKeyName == "" {
 		primaryKeyName = "id"
 	}
 	if primaryKeyField := m.primaryKeyField(); primaryKeyField != nil {
 		primaryKeyFieldName = primaryKeyField.Name
+	}
+
+	structNameFirstLetter := strings.ToLower(m.StructName[0:1])
+	defaultOrderExpr := ""
+	if m.HasPrimaryKey {
+		defaultOrderExpr = fmt.Sprintf("%s desc", primaryKeyName)
 	}
 
 	// Parse the model template.
@@ -479,7 +493,7 @@ func (m *Model) generateCode() (string, error) {
 	err := tmpl.Execute(&result, map[string]interface{}{
 		"Package":               m.PackageName,
 		"StructName":            m.StructName,
-		"StructNameFirstLetter": strings.ToLower(m.StructName[0:1]),
+		"StructNameFirstLetter": structNameFirstLetter,
 		"StructNameLower":       strings.ToLower(m.StructName),
 		"TableName":             m.qualifiedTableName(),
 		"TableFields":           displayFields,
@@ -488,6 +502,7 @@ func (m *Model) generateCode() (string, error) {
 		"IDType":                m.IDType,
 		"PrimaryKeyName":        primaryKeyName,
 		"PrimaryKeyFieldName":   primaryKeyFieldName,
+		"DefaultOrderExpr":      defaultOrderExpr,
 		"HasPrimaryKey":         m.HasPrimaryKey,
 	})
 	if err != nil {
@@ -979,7 +994,11 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 	}
 
 	// Perform the database query with context.
+	{{- if .HasPrimaryKey}}
 	if err := query.Order("{{.PrimaryKeyName}} desc").First(&{{.StructNameLower}}).Error; err != nil {
+	{{- else}}
+	if err := query.Last(&{{.StructNameLower}}).Error; err != nil {
+	{{- end}}
 		// If no record is found, return nil without an error.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -1006,7 +1025,11 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, d
 		return *new({{.IDType}}), fmt.Errorf("create failed: %w", err)
 	}
 
+	{{- if .HasPrimaryKey}}
 	return {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}}, nil
+	{{- else}}
+	return *new({{.IDType}}), nil
+	{{- end}}
 }
 
 // Delete removes the {{.StructNameLower}} from the database.
@@ -1109,8 +1132,13 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) List(ctx context.Context, db 
 func ({{.StructNameFirstLetter}} *{{.StructName}}) ListByArgs(ctx context.Context, db *gorm.DB, query interface{}, args ...interface{}) ([]{{.StructName}}, error) {
 	var {{.StructNameLower}}s []{{.StructName}}
 
+	queryBuilder := db.WithContext(ctx).Model(&{{.StructName}}{}).Where(query, args...)
+	{{- if .HasPrimaryKey}}
+	queryBuilder = queryBuilder.Order("{{.DefaultOrderExpr}}")
+	{{- end}}
+
 	// Perform the database query with context.
-	if err := db.WithContext(ctx).Model(&{{.StructName}}{}).Where(query, args...).Order("id desc").Find(&{{.StructNameLower}}s).Error; err != nil {
+	if err := queryBuilder.Find(&{{.StructNameLower}}s).Error; err != nil {
 		return nil, fmt.Errorf("list by args failed: %w", err)
 	}
 

--- a/command/codegen/codegen/model.go
+++ b/command/codegen/codegen/model.go
@@ -40,17 +40,18 @@ type Field struct {
 
 // Model represents the structure of a database table.
 type Model struct {
-	PackageName    string              // The package name for the generated Go file
-	Imports        map[string]struct{} // Imports required by the Go file
-	StructName     string              // The name of the Go struct
-	TableName      string              // The unqualified table name
-	SchemaName     string              // Optional schema name
-	TableFields    []Field             // The fields of the table
-	UseGormModel   bool                // Whether the generated model can embed gorm.Model
-	IDType         string              // Primary key type used by generated methods
-	PrimaryKeyName string              // Primary key column name
-	HasPrimaryKey  bool                // Whether the table defines a single-column primary key
-	Dialect        string              // SQL dialect used by the parser
+	PackageName            string              // The package name for the generated Go file
+	Imports                map[string]struct{} // Imports required by the Go file
+	StructName             string              // The name of the Go struct
+	TableName              string              // The unqualified table name
+	SchemaName             string              // Optional schema name
+	TableFields            []Field             // The fields of the table
+	UseGormModel           bool                // Whether the generated model can embed gorm.Model
+	IDType                 string              // Primary key type used by generated methods
+	PrimaryKeyName         string              // Single-column primary key column name
+	HasPrimaryKey          bool                // Whether the table defines a single-column primary key
+	HasCompositePrimaryKey bool                // Whether the table defines a composite primary key
+	Dialect                string              // SQL dialect used by the parser
 }
 
 // NewModel creates a new instance of Model.
@@ -94,6 +95,9 @@ func (m *Model) getGoType(sqlType string, isUnsigned, isNullable bool) (string, 
 	}
 
 	if m.Dialect == "postgres" {
+		if isPostgresArrayType(normalizedType) {
+			return makeNullable("any", "")
+		}
 		switch {
 		case strings.HasPrefix(normalizedType, "smallserial"):
 			return makeNullable("int16", "")
@@ -101,7 +105,7 @@ func (m *Model) getGoType(sqlType string, isUnsigned, isNullable bool) (string, 
 			return makeNullable("int32", "")
 		case strings.HasPrefix(normalizedType, "bigserial"):
 			return makeNullable("int64", "")
-		case strings.HasPrefix(normalizedType, "character varying"), strings.HasPrefix(normalizedType, "varchar"):
+		case isPostgresScalarVarcharType(normalizedType):
 			return makeNullable("string", "")
 		case strings.HasPrefix(normalizedType, "uuid"):
 			return makeNullable("string", "")
@@ -175,6 +179,23 @@ func (m *Model) getGoType(sqlType string, isUnsigned, isNullable bool) (string, 
 	}
 }
 
+func isPostgresArrayType(typeStr string) bool {
+	normalizedType := strings.ToLower(strings.TrimSpace(typeStr))
+	return strings.Contains(normalizedType, "[]")
+}
+
+func isPostgresScalarVarcharType(typeStr string) bool {
+	normalizedType := strings.ToLower(strings.TrimSpace(typeStr))
+	if isPostgresArrayType(normalizedType) {
+		return false
+	}
+
+	return normalizedType == "character varying" ||
+		strings.HasPrefix(normalizedType, "character varying(") ||
+		normalizedType == "varchar" ||
+		strings.HasPrefix(normalizedType, "varchar(")
+}
+
 // parseSQL parses the provided SQL schema string to extract table and field information.
 // It updates the Model struct with the extracted information.
 //
@@ -193,6 +214,7 @@ func (m *Model) parseSQL(sql string) error {
 	m.SchemaName = ""
 	m.PrimaryKeyName = ""
 	m.HasPrimaryKey = false
+	m.HasCompositePrimaryKey = false
 	m.IDType = ""
 	m.UseGormModel = false
 
@@ -221,13 +243,13 @@ func (m *Model) parseSQL(sql string) error {
 			}
 		case "primary", "unique", "key", "index", "foreign", "engine", "default", "collate", "comment":
 			// Ignore constraint, index, and table-level configuration lines.
-			if primaryKeyName := m.extractPrimaryKeyName(originalLine); primaryKeyName != "" {
-				m.markPrimaryKey(primaryKeyName)
+			if primaryKeyColumns := m.extractPrimaryKeyColumns(originalLine); len(primaryKeyColumns) > 0 {
+				m.markPrimaryKeys(primaryKeyColumns)
 			}
 			continue
 		case "constraint":
-			if primaryKeyName := m.extractPrimaryKeyName(originalLine); primaryKeyName != "" {
-				m.markPrimaryKey(primaryKeyName)
+			if primaryKeyColumns := m.extractPrimaryKeyColumns(originalLine); len(primaryKeyColumns) > 0 {
+				m.markPrimaryKeys(primaryKeyColumns)
 			}
 			continue
 		default:
@@ -255,6 +277,7 @@ func (m *Model) parseSQL(sql string) error {
 		}
 	}
 
+	m.refreshPrimaryKeyMetadata()
 	m.UseGormModel = m.canUseGormModel()
 	if prioritizedField := m.prioritizedField(); prioritizedField != nil {
 		m.IDType = m.generatedIDType(prioritizedField)
@@ -320,11 +343,6 @@ func (m *Model) parseFieldDefinition(originalLine, fieldName string, parts []str
 	// Determine the Go type and any required import for the field.
 	fieldType, importPath := m.getGoType(typeStr, field.IsUnsigned, field.IsNullable)
 	field.Type = fieldType
-	if field.IsPrimaryKey {
-		m.HasPrimaryKey = true
-		m.PrimaryKeyName = field.JsonName
-		m.IDType = fieldType
-	}
 
 	if importPath != "" {
 		m.Imports[importPath] = struct{}{}
@@ -400,7 +418,8 @@ func (m *Model) generateGormTag(field *Field, typeStr string) string {
 	tags = append(tags, fmt.Sprintf("column:%s", field.JsonName))
 
 	// Type specification for certain types
-	baseType := strings.ToLower(strings.Split(typeStr, "(")[0])
+	normalizedType := strings.ToLower(strings.TrimSpace(typeStr))
+	baseType := strings.ToLower(strings.Split(normalizedType, "(")[0])
 	if m.Dialect == "mysql" {
 		switch baseType {
 		case "varchar", "char":
@@ -416,7 +435,7 @@ func (m *Model) generateGormTag(field *Field, typeStr string) string {
 		case "text", "tinytext", "mediumtext", "longtext":
 			tags = append(tags, fmt.Sprintf("type:%s", baseType))
 		}
-	} else {
+	} else if !isPostgresArrayType(normalizedType) {
 		switch baseType {
 		case "numeric":
 			if field.Size > 0 && field.Scale > 0 {
@@ -473,25 +492,17 @@ func (m *Model) generateCode() (string, error) {
 
 	displayFields := m.templateFields()
 	primaryKeyFieldName := ""
-	primaryKeyName := m.PrimaryKeyName
-	if primaryKeyName == "" {
-		primaryKeyName = "id"
-	}
 	if primaryKeyField := m.primaryKeyField(); primaryKeyField != nil {
 		primaryKeyFieldName = primaryKeyField.Name
 	}
-	prioritizedFieldName := ""
-	hasPrioritizedField := false
-	prioritizedField := m.prioritizedField()
-	if prioritizedField != nil {
-		hasPrioritizedField = true
-		prioritizedFieldName = m.generatedFieldName(prioritizedField)
-	}
+	identifierColumnName := m.identifierColumnName()
+	identifierFieldName := m.identifierFieldName()
+	supportsSingleIdentifierOps := m.supportsSingleIdentifierOps()
 
 	structNameFirstLetter := strings.ToLower(m.StructName[0:1])
 	defaultOrderExpr := ""
-	if prioritizedField != nil {
-		defaultOrderExpr = fmt.Sprintf("%s desc", prioritizedField.JsonName)
+	if supportsSingleIdentifierOps {
+		defaultOrderExpr = fmt.Sprintf("%s desc", identifierColumnName)
 	}
 
 	// Parse the model template.
@@ -499,21 +510,23 @@ func (m *Model) generateCode() (string, error) {
 	var result strings.Builder
 	// Execute the template with the model data.
 	err := tmpl.Execute(&result, map[string]interface{}{
-		"Package":               m.PackageName,
-		"StructName":            m.StructName,
-		"StructNameFirstLetter": structNameFirstLetter,
-		"StructNameLower":       strings.ToLower(m.StructName),
-		"TableName":             m.qualifiedTableName(),
-		"TableFields":           displayFields,
-		"Imports":               m.Imports,
-		"UseGormModel":          m.UseGormModel,
-		"IDType":                m.IDType,
-		"PrimaryKeyName":        primaryKeyName,
-		"PrimaryKeyFieldName":   primaryKeyFieldName,
-		"PrioritizedFieldName":  prioritizedFieldName,
-		"HasPrioritizedField":   hasPrioritizedField,
-		"DefaultOrderExpr":      defaultOrderExpr,
-		"HasPrimaryKey":         m.HasPrimaryKey,
+		"Package":                     m.PackageName,
+		"StructName":                  m.StructName,
+		"StructNameFirstLetter":       structNameFirstLetter,
+		"StructNameLower":             strings.ToLower(m.StructName),
+		"TableName":                   m.qualifiedTableName(),
+		"TableFields":                 displayFields,
+		"Imports":                     m.Imports,
+		"UseGormModel":                m.UseGormModel,
+		"IDType":                      m.IDType,
+		"PrimaryKeyName":              m.PrimaryKeyName,
+		"PrimaryKeyFieldName":         primaryKeyFieldName,
+		"IdentifierColumnName":        identifierColumnName,
+		"IdentifierFieldName":         identifierFieldName,
+		"SupportsSingleIdentifierOps": supportsSingleIdentifierOps,
+		"DefaultOrderExpr":            defaultOrderExpr,
+		"HasPrimaryKey":               m.HasPrimaryKey,
+		"HasCompositePrimaryKey":      m.HasCompositePrimaryKey,
 	})
 	if err != nil {
 		return "", err
@@ -652,38 +665,42 @@ func (m *Model) extractTypeDefinition(parts []string) string {
 	return strings.Join(typeParts, " ")
 }
 
-func (m *Model) extractPrimaryKeyName(line string) string {
+func (m *Model) extractPrimaryKeyColumns(line string) []string {
 	re := regexp.MustCompile(`(?i)primary\s+key\s*\(([^)]+)\)`)
 	matches := re.FindStringSubmatch(line)
 	if len(matches) < 2 {
-		return ""
+		return nil
 	}
 
 	columns := strings.Split(matches[1], ",")
-	if len(columns) != 1 {
-		return ""
-	}
-
-	return m.cleanIdentifier(columns[0])
-}
-
-func (m *Model) markPrimaryKey(columnName string) {
-	for i := range m.TableFields {
-		if m.TableFields[i].JsonName != columnName {
+	result := make([]string, 0, len(columns))
+	for _, column := range columns {
+		cleaned := m.cleanIdentifier(column)
+		if cleaned == "" {
 			continue
 		}
-		m.TableFields[i].IsPrimaryKey = true
-		m.TableFields[i].IsNullable = false
-		fieldType, importPath := m.getGoType(m.TableFields[i].SQLType, m.TableFields[i].IsUnsigned, m.TableFields[i].IsNullable)
-		m.TableFields[i].Type = fieldType
-		if importPath != "" {
-			m.Imports[importPath] = struct{}{}
+		result = append(result, cleaned)
+	}
+
+	return result
+}
+
+func (m *Model) markPrimaryKeys(columnNames []string) {
+	for _, columnName := range columnNames {
+		for i := range m.TableFields {
+			if m.TableFields[i].JsonName != columnName {
+				continue
+			}
+			m.TableFields[i].IsPrimaryKey = true
+			m.TableFields[i].IsNullable = false
+			fieldType, importPath := m.getGoType(m.TableFields[i].SQLType, m.TableFields[i].IsUnsigned, m.TableFields[i].IsNullable)
+			m.TableFields[i].Type = fieldType
+			if importPath != "" {
+				m.Imports[importPath] = struct{}{}
+			}
+			m.TableFields[i].GormTag = m.generateGormTag(&m.TableFields[i], m.TableFields[i].SQLType)
+			break
 		}
-		m.HasPrimaryKey = true
-		m.PrimaryKeyName = columnName
-		m.IDType = m.TableFields[i].Type
-		m.TableFields[i].GormTag = m.generateGormTag(&m.TableFields[i], m.TableFields[i].SQLType)
-		return
 	}
 }
 
@@ -728,16 +745,48 @@ func (m *Model) templateFields() []Field {
 	return fields
 }
 
-func (m *Model) primaryKeyField() *Field {
+func (m *Model) primaryKeyFields() []*Field {
+	fields := make([]*Field, 0, len(m.TableFields))
 	for i := range m.TableFields {
-		if m.TableFields[i].IsPrimaryKey {
-			return &m.TableFields[i]
+		if !m.TableFields[i].IsPrimaryKey {
+			continue
 		}
+		fields = append(fields, &m.TableFields[i])
 	}
-	return nil
+	return fields
+}
+
+func (m *Model) refreshPrimaryKeyMetadata() {
+	m.PrimaryKeyName = ""
+	m.HasPrimaryKey = false
+	m.HasCompositePrimaryKey = false
+	m.IDType = ""
+
+	primaryKeyFields := m.primaryKeyFields()
+	switch len(primaryKeyFields) {
+	case 0:
+		return
+	case 1:
+		m.HasPrimaryKey = true
+		m.PrimaryKeyName = primaryKeyFields[0].JsonName
+		m.IDType = primaryKeyFields[0].Type
+	default:
+		m.HasCompositePrimaryKey = true
+	}
+}
+
+func (m *Model) primaryKeyField() *Field {
+	primaryKeyFields := m.primaryKeyFields()
+	if len(primaryKeyFields) != 1 {
+		return nil
+	}
+	return primaryKeyFields[0]
 }
 
 func (m *Model) prioritizedField() *Field {
+	if len(m.primaryKeyFields()) > 1 {
+		return nil
+	}
 	if primaryKeyField := m.primaryKeyField(); primaryKeyField != nil {
 		return primaryKeyField
 	}
@@ -749,6 +798,24 @@ func (m *Model) prioritizedField() *Field {
 	}
 
 	return nil
+}
+
+func (m *Model) supportsSingleIdentifierOps() bool {
+	return m.prioritizedField() != nil
+}
+
+func (m *Model) identifierColumnName() string {
+	if prioritizedField := m.prioritizedField(); prioritizedField != nil {
+		return prioritizedField.JsonName
+	}
+	return ""
+}
+
+func (m *Model) identifierFieldName() string {
+	if prioritizedField := m.prioritizedField(); prioritizedField != nil {
+		return m.generatedFieldName(prioritizedField)
+	}
+	return ""
 }
 
 func (m *Model) generatedIDType(field *Field) string {
@@ -1038,12 +1105,8 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 	}
 
 	// Perform the database query with context.
-	{{- if .HasPrioritizedField}}
+	{{- if .SupportsSingleIdentifierOps}}
 	if err := query.Order("{{.DefaultOrderExpr}}").First(&{{.StructNameLower}}).Error; err != nil {
-	{{- else}}
-	return nil, fmt.Errorf("find last failed: no primary key or id field available for ordering")
-	{{- end}}
-	{{- if .HasPrioritizedField}}
 		// If no record is found, return nil without an error.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -1051,19 +1114,21 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 		// Return the error if the query fails.
 		return nil, fmt.Errorf("find last failed: %w", err)
 	}
-	{{- end}}
 
 	return &{{.StructNameLower}}, nil
+	{{- else}}
+	return nil, fmt.Errorf("find last failed: no primary key or id field available for ordering")
+	{{- end}}
 }
 
-// Create inserts a new {{.StructNameLower}} into the database and returns the ID of the created {{.StructName}}.
+// Create inserts a new {{.StructNameLower}} into the database and returns its single identifier when available.
 //
 // Parameters:
 // 	- ctx: context.Context for managing request-scoped values, cancellation signals, and deadlines.
 // 	- db: *gorm.DB database connection.
 //
 // Returns:
-// 	- uint: ID of the created {{.StructNameLower}}.
+// 	- {{.IDType}}: identifier of the created {{.StructNameLower}} when a single identifier field is available, otherwise the zero value.
 // 	- error: error if the insert operation fails, otherwise nil.
 func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, db *gorm.DB) ({{.IDType}}, error) {
 	// Perform the database insert operation with context.
@@ -1071,8 +1136,8 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, d
 		return *new({{.IDType}}), fmt.Errorf("create failed: %w", err)
 	}
 
-	{{- if .HasPrioritizedField}}
-	return {{.StructNameFirstLetter}}.{{.PrioritizedFieldName}}, nil
+	{{- if .SupportsSingleIdentifierOps}}
+	return {{.StructNameFirstLetter}}.{{.IdentifierFieldName}}, nil
 	{{- else}}
 	return *new({{.IDType}}), nil
 	{{- end}}
@@ -1117,10 +1182,10 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Updates(ctx context.Context, 
 	if {{.StructNameFirstLetter}}.queryCondition != nil {
 		query = query.Where({{.StructNameFirstLetter}}.queryCondition, {{.StructNameFirstLetter}}.queryArgs...)
 	} else {
-		{{- if .HasPrimaryKey}}
-		if {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}} != *new({{.IDType}}) {
-			// Use primary key for updates if available.
-			query = query.Where("{{.PrimaryKeyName}} = ?", {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}})
+		{{- if .SupportsSingleIdentifierOps}}
+		if {{.StructNameFirstLetter}}.{{.IdentifierFieldName}} != *new({{.IDType}}) {
+			// Use the single identifier field for updates when available.
+			query = query.Where("{{.IdentifierColumnName}} = ?", {{.StructNameFirstLetter}}.{{.IdentifierFieldName}})
 		} else {
 			// Use struct fields as condition
 			query = query.Where({{.StructNameFirstLetter}})
@@ -1164,7 +1229,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) List(ctx context.Context, db 
 	return {{.StructNameLower}}s, nil
 }
 
-// ListByArgs retrieves {{.StructNameLower}}s matching the specified query and arguments from the database, ordered by ID in descending order.
+// ListByArgs retrieves {{.StructNameLower}}s matching the specified query and arguments from the database, ordered by primary key or id in descending order when available.
 //
 // Parameters:
 // 	- ctx: context.Context for managing request-scoped values, cancellation signals, and deadlines.
@@ -1179,7 +1244,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) ListByArgs(ctx context.Contex
 	var {{.StructNameLower}}s []{{.StructName}}
 
 	queryBuilder := db.WithContext(ctx).Model(&{{.StructName}}{}).Where(query, args...)
-	{{- if .HasPrioritizedField}}
+	{{- if .SupportsSingleIdentifierOps}}
 	queryBuilder = queryBuilder.Order("{{.DefaultOrderExpr}}")
 	{{- end}}
 

--- a/command/codegen/codegen/model.go
+++ b/command/codegen/codegen/model.go
@@ -256,8 +256,8 @@ func (m *Model) parseSQL(sql string) error {
 	}
 
 	m.UseGormModel = m.canUseGormModel()
-	if m.IDType == "" && m.HasPrimaryKey {
-		m.IDType = "uint"
+	if prioritizedField := m.prioritizedField(); prioritizedField != nil {
+		m.IDType = m.generatedIDType(prioritizedField)
 	} else if m.IDType == "" {
 		m.IDType = "uint"
 	}
@@ -295,6 +295,7 @@ func (m *Model) parseFieldDefinition(originalLine, fieldName string, parts []str
 		upperLine := strings.ToUpper(originalLine)
 		if strings.Contains(upperLine, "GENERATED") && strings.Contains(upperLine, "AS IDENTITY") {
 			field.IsAutoIncrement = true
+			field.IsNullable = false
 		}
 		if strings.HasPrefix(strings.ToLower(typeStr), "serial") || strings.HasPrefix(strings.ToLower(typeStr), "bigserial") || strings.HasPrefix(strings.ToLower(typeStr), "smallserial") {
 			field.IsAutoIncrement = true
@@ -479,11 +480,18 @@ func (m *Model) generateCode() (string, error) {
 	if primaryKeyField := m.primaryKeyField(); primaryKeyField != nil {
 		primaryKeyFieldName = primaryKeyField.Name
 	}
+	prioritizedFieldName := ""
+	hasPrioritizedField := false
+	prioritizedField := m.prioritizedField()
+	if prioritizedField != nil {
+		hasPrioritizedField = true
+		prioritizedFieldName = m.generatedFieldName(prioritizedField)
+	}
 
 	structNameFirstLetter := strings.ToLower(m.StructName[0:1])
 	defaultOrderExpr := ""
-	if m.HasPrimaryKey {
-		defaultOrderExpr = fmt.Sprintf("%s desc", primaryKeyName)
+	if prioritizedField != nil {
+		defaultOrderExpr = fmt.Sprintf("%s desc", prioritizedField.JsonName)
 	}
 
 	// Parse the model template.
@@ -502,6 +510,8 @@ func (m *Model) generateCode() (string, error) {
 		"IDType":                m.IDType,
 		"PrimaryKeyName":        primaryKeyName,
 		"PrimaryKeyFieldName":   primaryKeyFieldName,
+		"PrioritizedFieldName":  prioritizedFieldName,
+		"HasPrioritizedField":   hasPrioritizedField,
 		"DefaultOrderExpr":      defaultOrderExpr,
 		"HasPrimaryKey":         m.HasPrimaryKey,
 	})
@@ -725,6 +735,40 @@ func (m *Model) primaryKeyField() *Field {
 		}
 	}
 	return nil
+}
+
+func (m *Model) prioritizedField() *Field {
+	if primaryKeyField := m.primaryKeyField(); primaryKeyField != nil {
+		return primaryKeyField
+	}
+
+	for i := range m.TableFields {
+		if strings.EqualFold(m.TableFields[i].JsonName, "id") {
+			return &m.TableFields[i]
+		}
+	}
+
+	return nil
+}
+
+func (m *Model) generatedIDType(field *Field) string {
+	if field == nil {
+		return "uint"
+	}
+	if m.UseGormModel && strings.EqualFold(field.JsonName, "id") {
+		return "uint"
+	}
+	return field.Type
+}
+
+func (m *Model) generatedFieldName(field *Field) string {
+	if field == nil {
+		return ""
+	}
+	if m.UseGormModel && strings.EqualFold(field.JsonName, "id") {
+		return "ID"
+	}
+	return field.Name
 }
 
 // readSQLFile reads the content of the specified SQL file.
@@ -972,7 +1016,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) First(ctx context.Context, db
 	return &{{.StructNameLower}}, nil
 }
 
-// Last retrieves the last {{.StructNameLower}} matching the criteria from the database, ordered by ID in descending order.
+// Last retrieves the last {{.StructNameLower}} matching the criteria from the database, ordered by primary key or id in descending order when available.
 //
 // Parameters:
 // 	- ctx: context.Context for managing request-scoped values, cancellation signals, and deadlines.
@@ -994,11 +1038,12 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 	}
 
 	// Perform the database query with context.
-	{{- if .HasPrimaryKey}}
-	if err := query.Order("{{.PrimaryKeyName}} desc").First(&{{.StructNameLower}}).Error; err != nil {
+	{{- if .HasPrioritizedField}}
+	if err := query.Order("{{.DefaultOrderExpr}}").First(&{{.StructNameLower}}).Error; err != nil {
 	{{- else}}
-	if err := query.Last(&{{.StructNameLower}}).Error; err != nil {
+	return nil, fmt.Errorf("find last failed: no primary key or id field available for ordering")
 	{{- end}}
+	{{- if .HasPrioritizedField}}
 		// If no record is found, return nil without an error.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -1006,6 +1051,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Last(ctx context.Context, db 
 		// Return the error if the query fails.
 		return nil, fmt.Errorf("find last failed: %w", err)
 	}
+	{{- end}}
 
 	return &{{.StructNameLower}}, nil
 }
@@ -1025,8 +1071,8 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) Create(ctx context.Context, d
 		return *new({{.IDType}}), fmt.Errorf("create failed: %w", err)
 	}
 
-	{{- if .HasPrimaryKey}}
-	return {{.StructNameFirstLetter}}.{{.PrimaryKeyFieldName}}, nil
+	{{- if .HasPrioritizedField}}
+	return {{.StructNameFirstLetter}}.{{.PrioritizedFieldName}}, nil
 	{{- else}}
 	return *new({{.IDType}}), nil
 	{{- end}}

--- a/command/codegen/codegen/model.go
+++ b/command/codegen/codegen/model.go
@@ -1179,7 +1179,7 @@ func ({{.StructNameFirstLetter}} *{{.StructName}}) ListByArgs(ctx context.Contex
 	var {{.StructNameLower}}s []{{.StructName}}
 
 	queryBuilder := db.WithContext(ctx).Model(&{{.StructName}}{}).Where(query, args...)
-	{{- if .HasPrimaryKey}}
+	{{- if .HasPrioritizedField}}
 	queryBuilder = queryBuilder.Order("{{.DefaultOrderExpr}}")
 	{{- end}}
 

--- a/command/codegen/codegen/model_test.go
+++ b/command/codegen/codegen/model_test.go
@@ -544,3 +544,95 @@ func TestModel_generateCodeCreateUsesTypedZeroValueOnError(t *testing.T) {
 		t.Fatalf("expected create error branch to return typed zero value, got:\n%s", code)
 	}
 }
+
+func TestModel_generateCodeWithoutPrimaryKeyCreateNoInvalidField(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE logs (
+		message text NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if strings.Contains(code, ".ID, nil") {
+		t.Fatalf("create branch should not return missing ID field when table has no primary key, got:\n%s", code)
+	}
+	if !strings.Contains(code, "return *new(uint), nil") {
+		t.Fatalf("create branch should return typed zero value when no primary key, got:\n%s", code)
+	}
+}
+
+func TestModel_generateCodeListByArgsUsesPrimaryKeyOrder(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE oauth_apps (
+		app_uuid uuid PRIMARY KEY,
+		name varchar(80) NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if !strings.Contains(code, `queryBuilder = queryBuilder.Order("app_uuid desc")`) {
+		t.Fatalf("expected ListByArgs to use parsed primary key for order, got:\n%s", code)
+	}
+	if strings.Contains(code, `Order("id desc")`) {
+		t.Fatalf("expected ListByArgs not to hardcode id ordering, got:\n%s", code)
+	}
+}
+
+func TestModel_generateCodeEmptyTableNameReturnsError(t *testing.T) {
+	m := NewModel()
+
+	if _, err := m.generateCode(); err == nil {
+		t.Fatal("expected generateCode() to return error when table name is empty")
+	}
+}
+
+func TestModel_getGoTypePostgresCharacterVarying(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+
+	result, _ := m.getGoType("character varying(80)", false, false)
+	if result != "string" {
+		t.Fatalf("getGoType(character varying(80)) = %s, want string", result)
+	}
+
+	nullableResult, _ := m.getGoType("character varying(80)", false, true)
+	if nullableResult != "*string" {
+		t.Fatalf("getGoType(nullable character varying(80)) = %s, want *string", nullableResult)
+	}
+}
+
+func TestModel_parseSQLPostgresFieldWithCollate(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE "public"."users" (
+		"name" character varying(80) COLLATE "en_US" NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if len(m.TableFields) != 1 {
+		t.Fatalf("expected 1 parsed field, got %d", len(m.TableFields))
+	}
+
+	field := m.TableFields[0]
+	if field.JsonName != "name" {
+		t.Fatalf("field.JsonName = %s, want name", field.JsonName)
+	}
+	if field.Type != "string" {
+		t.Fatalf("field.Type = %s, want string", field.Type)
+	}
+}

--- a/command/codegen/codegen/model_test.go
+++ b/command/codegen/codegen/model_test.go
@@ -7,6 +7,7 @@ package codegen
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -565,6 +566,102 @@ func TestModel_generateCodeWithoutPrimaryKeyCreateNoInvalidField(t *testing.T) {
 	}
 	if !strings.Contains(code, "return *new(uint), nil") {
 		t.Fatalf("create branch should return typed zero value when no primary key, got:\n%s", code)
+	}
+}
+
+func TestModel_generateCodeCreateUsesImplicitIDField(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE logs (
+		id bigint generated always as identity,
+		message text NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if m.HasPrimaryKey {
+		t.Fatal("implicit id should not be treated as explicit primary key metadata")
+	}
+	if m.IDType != "int64" {
+		t.Fatalf("IDType = %s, want int64", m.IDType)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if !strings.Contains(code, "func (l *Log) Create(ctx context.Context, db *gorm.DB) (int64, error)") {
+		t.Fatalf("expected create signature to use implicit id type, got:\n%s", code)
+	}
+	matched, err := regexp.MatchString(`return l\.(ID|Id), nil`, code)
+	if err != nil {
+		t.Fatalf("regexp.MatchString() error = %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected create branch to return implicit id field, got:\n%s", code)
+	}
+	if !strings.Contains(code, `query.Order("id desc").First(&log).Error`) {
+		t.Fatalf("expected Last to order by implicit id field, got:\n%s", code)
+	}
+}
+
+func TestModel_generateCodeWithoutPrimaryKeyOrIDLastReturnsError(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE logs (
+		message text NOT NULL,
+		created_at bigint NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if strings.Contains(code, "query.Last(&log).Error") {
+		t.Fatalf("Last should not fall back to query.Last without an ordering field, got:\n%s", code)
+	}
+	if !strings.Contains(code, `return nil, fmt.Errorf("find last failed: no primary key or id field available for ordering")`) {
+		t.Fatalf("expected Last to return a clear error when no ordering field exists, got:\n%s", code)
+	}
+}
+
+func TestModel_generateCodeCreateUsesEmbeddedGormModelIDForImplicitID(t *testing.T) {
+	m := NewModelWithDialect("mysql")
+	sqlContent := `CREATE TABLE auth_app (
+		id int NOT NULL AUTO_INCREMENT,
+		app_id varchar(30) NOT NULL,
+		created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+		deleted_at timestamp NULL DEFAULT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if !m.UseGormModel {
+		t.Fatal("expected standard columns to embed gorm.Model")
+	}
+	if m.IDType != "uint" {
+		t.Fatalf("IDType = %s, want uint", m.IDType)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if !strings.Contains(code, "func (a *App) Create(ctx context.Context, db *gorm.DB) (uint, error)") {
+		t.Fatalf("expected create signature to use embedded gorm.Model ID type, got:\n%s", code)
+	}
+	if !strings.Contains(code, "return a.ID, nil") {
+		t.Fatalf("expected create branch to return embedded gorm.Model ID, got:\n%s", code)
 	}
 }
 

--- a/command/codegen/codegen/model_test.go
+++ b/command/codegen/codegen/model_test.go
@@ -12,6 +12,14 @@ import (
 	"testing"
 )
 
+func assertGeneratedModelCodeFormats(t *testing.T, m *Model, code string) {
+	t.Helper()
+
+	if _, err := m.formatGoCode(code); err != nil {
+		t.Fatalf("generated model code is not valid Go: %v\n%s", err, code)
+	}
+}
+
 // TestModel_Generate tests the complete model generation process
 func TestModel_Generate(t *testing.T) {
 	m := NewModel()
@@ -605,6 +613,10 @@ func TestModel_generateCodeCreateUsesImplicitIDField(t *testing.T) {
 	if !strings.Contains(code, `query.Order("id desc").First(&log).Error`) {
 		t.Fatalf("expected Last to order by implicit id field, got:\n%s", code)
 	}
+	if !strings.Contains(code, `query = query.Where("id = ?", l.Id)`) {
+		t.Fatalf("expected Updates to use implicit id field, got:\n%s", code)
+	}
+	assertGeneratedModelCodeFormats(t, m, code)
 }
 
 func TestModel_generateCodeWithoutPrimaryKeyOrIDLastReturnsError(t *testing.T) {
@@ -629,6 +641,7 @@ func TestModel_generateCodeWithoutPrimaryKeyOrIDLastReturnsError(t *testing.T) {
 	if !strings.Contains(code, `return nil, fmt.Errorf("find last failed: no primary key or id field available for ordering")`) {
 		t.Fatalf("expected Last to return a clear error when no ordering field exists, got:\n%s", code)
 	}
+	assertGeneratedModelCodeFormats(t, m, code)
 }
 
 func TestModel_generateCodeCreateUsesEmbeddedGormModelIDForImplicitID(t *testing.T) {
@@ -708,6 +721,54 @@ func TestModel_generateCodeListByArgsUsesImplicitIDOrder(t *testing.T) {
 	if !strings.Contains(code, `queryBuilder = queryBuilder.Order("id desc")`) {
 		t.Fatalf("expected ListByArgs to use implicit id ordering, got:\n%s", code)
 	}
+	assertGeneratedModelCodeFormats(t, m, code)
+}
+
+func TestModel_parseSQLCompositePrimaryKeyDisablesImplicitIDFallback(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE logs (
+		tenant_id uuid NOT NULL,
+		id bigint NOT NULL,
+		message text NOT NULL,
+		PRIMARY KEY (tenant_id, id)
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if m.HasPrimaryKey {
+		t.Fatal("composite primary key should not be treated as a single-column primary key")
+	}
+	if !m.HasCompositePrimaryKey {
+		t.Fatal("expected composite primary key metadata to be recorded")
+	}
+	if m.PrimaryKeyName != "" {
+		t.Fatalf("PrimaryKeyName = %s, want empty for composite primary key", m.PrimaryKeyName)
+	}
+	if m.prioritizedField() != nil {
+		t.Fatal("composite primary key should disable implicit id fallback")
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	matched, err := regexp.MatchString(`return l\.(ID|Id), nil`, code)
+	if err != nil {
+		t.Fatalf("regexp.MatchString() error = %v", err)
+	}
+	if matched {
+		t.Fatalf("expected composite primary key model not to return a lone id field, got:\n%s", code)
+	}
+	if strings.Contains(code, `query.Order("id desc").First(&log).Error`) {
+		t.Fatalf("expected composite primary key model not to order by lone id, got:\n%s", code)
+	}
+	if strings.Contains(code, `queryBuilder = queryBuilder.Order("id desc")`) {
+		t.Fatalf("expected composite primary key model not to default ListByArgs ordering to id, got:\n%s", code)
+	}
+	assertGeneratedModelCodeFormats(t, m, code)
 }
 
 func TestModel_generateCodeEmptyTableNameReturnsError(t *testing.T) {
@@ -732,6 +793,28 @@ func TestModel_getGoTypePostgresCharacterVarying(t *testing.T) {
 	}
 }
 
+func TestModel_getGoTypePostgresVarcharArraysFallbackToAny(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+
+	testCases := []struct {
+		sqlType    string
+		isNullable bool
+		expectedGo string
+	}{
+		{sqlType: "varchar[]", isNullable: false, expectedGo: "any"},
+		{sqlType: "varchar(32)[]", isNullable: false, expectedGo: "any"},
+		{sqlType: "character varying[]", isNullable: true, expectedGo: "*any"},
+		{sqlType: "character varying(32)[]", isNullable: true, expectedGo: "*any"},
+	}
+
+	for _, tc := range testCases {
+		result, _ := m.getGoType(tc.sqlType, false, tc.isNullable)
+		if result != tc.expectedGo {
+			t.Fatalf("getGoType(%s) = %s, want %s", tc.sqlType, result, tc.expectedGo)
+		}
+	}
+}
+
 func TestModel_parseSQLPostgresFieldWithCollate(t *testing.T) {
 	m := NewModelWithDialect("postgres")
 	sqlContent := `CREATE TABLE "public"."users" (
@@ -752,5 +835,28 @@ func TestModel_parseSQLPostgresFieldWithCollate(t *testing.T) {
 	}
 	if field.Type != "string" {
 		t.Fatalf("field.Type = %s, want string", field.Type)
+	}
+}
+
+func TestModel_parseSQLPostgresArrayFieldFallsBackSafely(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE "public"."users" (
+		"tags" varchar(32)[] NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	if len(m.TableFields) != 1 {
+		t.Fatalf("expected 1 parsed field, got %d", len(m.TableFields))
+	}
+
+	field := m.TableFields[0]
+	if field.Type != "any" {
+		t.Fatalf("field.Type = %s, want any", field.Type)
+	}
+	if strings.Contains(field.GormTag, "type:varchar(32)") {
+		t.Fatalf("array field should not reuse scalar varchar tag, got %s", field.GormTag)
 	}
 }

--- a/command/codegen/codegen/model_test.go
+++ b/command/codegen/codegen/model_test.go
@@ -689,6 +689,27 @@ func TestModel_generateCodeListByArgsUsesPrimaryKeyOrder(t *testing.T) {
 	}
 }
 
+func TestModel_generateCodeListByArgsUsesImplicitIDOrder(t *testing.T) {
+	m := NewModelWithDialect("postgres")
+	sqlContent := `CREATE TABLE logs (
+		id bigint generated always as identity,
+		message text NOT NULL
+	);`
+
+	if err := m.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	code, err := m.generateCode()
+	if err != nil {
+		t.Fatalf("generateCode() error = %v", err)
+	}
+
+	if !strings.Contains(code, `queryBuilder = queryBuilder.Order("id desc")`) {
+		t.Fatalf("expected ListByArgs to use implicit id ordering, got:\n%s", code)
+	}
+}
+
 func TestModel_generateCodeEmptyTableNameReturnsError(t *testing.T) {
 	m := NewModel()
 

--- a/command/codegen/codegen/repository.go
+++ b/command/codegen/codegen/repository.go
@@ -31,6 +31,10 @@ type Repository struct {
 
 // NewRepository creates a new instance of Repository.
 func NewRepository(model *Model) *Repository {
+	if model != nil && model.TableName != "" && (model.PackageName == "" || model.StructName == "") {
+		model.PackageName, model.StructName = model.generateNames(model.TableName)
+	}
+
 	return &Repository{
 		Model:           model,
 		PackageName:     model.PackageName,
@@ -52,16 +56,29 @@ func NewRepository(model *Model) *Repository {
 //   - A string containing the generated Go code.
 //   - An error if there is an issue generating the code.
 func (r *Repository) generateCode() (string, error) {
+	if r.Model.TableName == "" {
+		return "", fmt.Errorf("repository generation requires a table name")
+	}
+	if r.Model.PackageName == "" || r.Model.StructName == "" {
+		r.Model.PackageName, r.Model.StructName = r.Model.generateNames(r.Model.TableName)
+	}
+
 	// Set the package name and struct name based on the model.
 	r.PackageName = r.Model.PackageName
 	r.StructName = r.Model.StructName
 	r.ModelStructName = r.Model.StructName
 	r.TableName = r.Model.TableName
 	r.IDType = r.Model.IDType
-	r.PrimaryKeyName = r.Model.PrimaryKeyName
-	if r.PrimaryKeyName == "" {
-		r.PrimaryKeyName = "id"
+	if r.IDType == "" {
+		r.IDType = r.Model.generatedIDType(r.Model.prioritizedField())
 	}
+	if !r.Model.supportsSingleIdentifierOps() {
+		if len(r.Model.primaryKeyFields()) > 1 {
+			return "", fmt.Errorf("repository generation does not support composite primary keys for table %s", r.Model.qualifiedTableName())
+		}
+		return "", fmt.Errorf("repository generation requires a single-column primary key or id field for table %s", r.Model.qualifiedTableName())
+	}
+	r.PrimaryKeyName = r.Model.identifierColumnName()
 
 	// Add required imports
 	r.Imports["errors"] = struct{}{}
@@ -109,12 +126,7 @@ func (r *Repository) generateCode() (string, error) {
 }
 
 func (r *Repository) primaryKeyFieldName() string {
-	for _, field := range r.Model.TableFields {
-		if field.JsonName == r.PrimaryKeyName {
-			return field.Name
-		}
-	}
-	return "ID"
+	return r.Model.identifierFieldName()
 }
 
 // generateFieldChecks generates field check code for the Update method

--- a/command/codegen/codegen/repository_test.go
+++ b/command/codegen/codegen/repository_test.go
@@ -11,6 +11,25 @@ import (
 	"testing"
 )
 
+func assertGeneratedRepositoryCodeFormats(t *testing.T, repo *Repository, code string) {
+	t.Helper()
+
+	if _, err := repo.formatGoCode(code); err != nil {
+		t.Fatalf("generated repository code is not valid Go: %v\n%s", err, code)
+	}
+}
+
+func mustParseRepositoryTestModel(t *testing.T, dialect, sqlContent string) *Model {
+	t.Helper()
+
+	model := NewModelWithDialect(dialect)
+	if err := model.parseSQL(sqlContent); err != nil {
+		t.Fatalf("parseSQL() error = %v", err)
+	}
+
+	return model
+}
+
 func TestRepository_generateCode(t *testing.T) {
 	// Create a test model
 	model := &Model{
@@ -20,16 +39,18 @@ func TestRepository_generateCode(t *testing.T) {
 		IDType:      "uint",
 		TableFields: []Field{
 			{
-				Name:    "ID",
-				Type:    "uint",
-				Comment: "// Primary key",
-				GormTag: `gorm:"primaryKey;autoIncrement"`,
+				Name:     "ID",
+				JsonName: "id",
+				Type:     "uint",
+				Comment:  "// Primary key",
+				GormTag:  `gorm:"primaryKey;autoIncrement"`,
 			},
 			{
-				Name:    "AppName",
-				Type:    "string",
-				Comment: "// Application name",
-				GormTag: `gorm:"type:varchar(255);not null"`,
+				Name:     "AppName",
+				JsonName: "app_name",
+				Type:     "string",
+				Comment:  "// Application name",
+				GormTag:  `gorm:"type:varchar(255);not null"`,
 			},
 		},
 	}
@@ -65,6 +86,7 @@ func TestRepository_generateCode(t *testing.T) {
 			t.Errorf("Generated code does not contain expected element: %s", element)
 		}
 	}
+	assertGeneratedRepositoryCodeFormats(t, repo, code)
 }
 
 func TestRepository_WriteRepositoryFile(t *testing.T) {
@@ -122,16 +144,18 @@ func TestRepository_Generate(t *testing.T) {
 		IDType:      "uint",
 		TableFields: []Field{
 			{
-				Name:    "ID",
-				Type:    "uint",
-				Comment: "// Primary key",
-				GormTag: `gorm:"primaryKey;autoIncrement"`,
+				Name:     "ID",
+				JsonName: "id",
+				Type:     "uint",
+				Comment:  "// Primary key",
+				GormTag:  `gorm:"primaryKey;autoIncrement"`,
 			},
 			{
-				Name:    "AppName",
-				Type:    "string",
-				Comment: "// Application name",
-				GormTag: `gorm:"type:varchar(255);not null"`,
+				Name:     "AppName",
+				JsonName: "app_name",
+				Type:     "string",
+				Comment:  "// Application name",
+				GormTag:  `gorm:"type:varchar(255);not null"`,
 			},
 		},
 	}
@@ -226,6 +250,7 @@ func TestRepository_GenerateCodeUsesCustomIDType(t *testing.T) {
 	if !strings.Contains(code, "GetByID(ctx context.Context, id int64)") {
 		t.Fatalf("expected generated repository to use int64 IDs, got:\n%s", code)
 	}
+	assertGeneratedRepositoryCodeFormats(t, repo, code)
 }
 
 func TestRepository_GenerateCodeUsesPostgresPrimaryKeyName(t *testing.T) {
@@ -252,5 +277,60 @@ func TestRepository_GenerateCodeUsesPostgresPrimaryKeyName(t *testing.T) {
 	}
 	if !strings.Contains(code, "updateModel.AppUuid = id") {
 		t.Fatalf("expected generated repository to assign custom primary key field, got:\n%s", code)
+	}
+	assertGeneratedRepositoryCodeFormats(t, repo, code)
+}
+
+func TestRepository_GenerateCodeUsesImplicitIDField(t *testing.T) {
+	model := mustParseRepositoryTestModel(t, "postgres", `CREATE TABLE logs (
+		id bigint generated always as identity,
+		message text NOT NULL
+	);`)
+
+	repo := NewRepository(model)
+	code, err := repo.generateCode()
+	if err != nil {
+		t.Fatalf("Failed to generate repository code: %v", err)
+	}
+
+	if !strings.Contains(code, `Where("id = ?", id)`) {
+		t.Fatalf("expected generated repository to query by implicit id field, got:\n%s", code)
+	}
+	if !strings.Contains(code, "updateModel.Id = id") {
+		t.Fatalf("expected generated repository to assign implicit id field, got:\n%s", code)
+	}
+	assertGeneratedRepositoryCodeFormats(t, repo, code)
+}
+
+func TestRepository_GenerateCodeRejectsCompositePrimaryKey(t *testing.T) {
+	model := mustParseRepositoryTestModel(t, "postgres", `CREATE TABLE logs (
+		tenant_id uuid NOT NULL,
+		id bigint NOT NULL,
+		message text NOT NULL,
+		PRIMARY KEY (tenant_id, id)
+	);`)
+
+	repo := NewRepository(model)
+	_, err := repo.generateCode()
+	if err == nil {
+		t.Fatal("expected repository generation to reject composite primary keys")
+	}
+	if !strings.Contains(err.Error(), "does not support composite primary keys") {
+		t.Fatalf("expected composite primary key error, got %v", err)
+	}
+}
+
+func TestRepository_GenerateCodeRejectsMissingIdentifier(t *testing.T) {
+	model := mustParseRepositoryTestModel(t, "postgres", `CREATE TABLE logs (
+		message text NOT NULL
+	);`)
+
+	repo := NewRepository(model)
+	_, err := repo.generateCode()
+	if err == nil {
+		t.Fatal("expected repository generation to reject tables without a single identifier field")
+	}
+	if !strings.Contains(err.Error(), "requires a single-column primary key or id field") {
+		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Harden PostgreSQL code generation around identifier selection and unsupported schema handling.

## Cause
The generator mixed explicit primary-key metadata with implicit prioritized fields.
That made different code paths disagree on the record identifier and introduced unsafe fallbacks for unsupported PostgreSQL schemas.

## Solution
- unify model and repository generation around a safe single-identifier path
- keep implicit `id` behavior for legacy and identity-backed tables in generated `Create`, `Last`, `Updates`, and `ListByArgs`
- reject repository generation for composite primary keys and tables without a safe single identifier
- prevent PostgreSQL `varchar[]` and `character varying[]` columns from being generated as scalar `string` fields
- add regression tests and generated-code format checks for implicit ids, composite keys, missing identifiers, and PostgreSQL array fallbacks

## Testing
- `go test -mod=mod ./command/codegen/codegen`